### PR TITLE
Refactor: Replace per-step caches with unified stepContexts

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub mod reference_images;
 pub mod scalemates;
 pub mod settings;
 pub mod sprue_refs;
+pub mod step_context;
 pub mod step_paint_refs;
 pub mod step_relations;
 pub mod step_sprue_parts;

--- a/src-tauri/src/commands/step_context.rs
+++ b/src-tauri/src/commands/step_context.rs
@@ -1,0 +1,23 @@
+use crate::db::AppDb;
+use crate::models::StepContext;
+use tauri::State;
+
+#[tauri::command]
+pub fn get_step_context(db: State<'_, AppDb>, step_id: String) -> Result<StepContext, String> {
+    let conn = db.conn()?;
+    let tags = crate::db::queries::tags::list_for_step(&conn, &step_id)?;
+    let relations = crate::db::queries::step_relations::list_for_step(&conn, &step_id)?;
+    let paint_refs = crate::db::queries::step_paint_refs::list_for_step(&conn, &step_id)?;
+    let sprue_parts = crate::db::queries::step_sprue_parts::list_for_step(&conn, &step_id)?;
+    let reference_images = crate::db::queries::reference_images::list_for_step(&conn, &step_id)?;
+    let annotations = crate::db::queries::annotations::get(&conn, &step_id)?;
+
+    Ok(StepContext {
+        tags,
+        relations,
+        paint_refs,
+        sprue_parts,
+        reference_images,
+        annotations,
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -146,6 +146,7 @@ pub fn run() {
             commands::drying_timers::delete_drying_timer,
             commands::annotations::get_annotations,
             commands::annotations::save_annotations,
+            commands::step_context::get_step_context,
             commands::step_paint_refs::list_step_paint_refs,
             commands::step_paint_refs::set_step_paint_refs,
             commands::step_paint_refs::list_project_step_paint_refs,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -693,3 +693,14 @@ pub struct BackupDiff {
     pub accessories: u64,
     pub photos: u64,
 }
+
+// ── Step Context (bundled per-step data) ────────────────────────────────
+#[derive(Debug, Clone, Serialize)]
+pub struct StepContext {
+    pub tags: Vec<Tag>,
+    pub relations: Vec<StepRelation>,
+    pub paint_refs: Vec<String>,
+    pub sprue_parts: Vec<StepSpruePart>,
+    pub reference_images: Vec<ReferenceImage>,
+    pub annotations: Option<StepAnnotations>,
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -50,6 +50,7 @@ import type {
   StepSpruePart,
   SprueDepletionSummary,
   DetectionResponse,
+  StepContext,
 } from "@/shared/types";
 
 // ── Kits ────────────────────────────────────────────────────────────────────
@@ -763,6 +764,25 @@ export async function setSpruePartTicked(id: string, tickedCount: number): Promi
 
 export async function sprueDepletionSummary(projectId: string): Promise<SprueDepletionSummary[]> {
   return invoke<SprueDepletionSummary[]>("sprue_depletion_summary", { projectId });
+}
+
+// ── Step Context ────────────────────────────────────────────────────────────
+
+interface RawStepContext {
+  tags: StepContext["tags"];
+  relations: StepContext["relations"];
+  paint_refs: StepContext["paint_refs"];
+  sprue_parts: StepContext["sprue_parts"];
+  reference_images: StepContext["reference_images"];
+  annotations: StepAnnotations | null;
+}
+
+export async function getStepContext(stepId: string): Promise<StepContext> {
+  const raw = await invoke<RawStepContext>("get_step_context", { stepId });
+  return {
+    ...raw,
+    annotations: raw.annotations ? (JSON.parse(raw.annotations.data) as Annotation[]) : [],
+  };
 }
 
 // ── AI Detection ────────────────────────────────────────────────────────────

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -186,10 +186,6 @@ export async function setPaletteComponents(
 
 // ── Step Paint Refs ─────────────────────────────────────────────────────
 
-export async function listStepPaintRefs(stepId: string): Promise<string[]> {
-  return invoke<string[]>("list_step_paint_refs", { stepId });
-}
-
 export async function setStepPaintRefs(
   stepId: string,
   entryIds: string[],
@@ -390,10 +386,6 @@ export async function listTags(): Promise<Tag[]> {
   return invoke<Tag[]>("list_tags");
 }
 
-export async function listStepTags(stepId: string): Promise<Tag[]> {
-  return invoke<Tag[]>("list_step_tags", { stepId });
-}
-
 export async function setStepTags(
   stepId: string,
   tagNames: string[],
@@ -419,10 +411,6 @@ export async function setStepRelations(
 }
 
 // ── Reference Images ─────────────────────────────────────────────────────────
-
-export async function listReferenceImages(stepId: string): Promise<ReferenceImage[]> {
-  return invoke<ReferenceImage[]>("list_reference_images", { stepId });
-}
 
 export async function addReferenceImage(
   stepId: string,
@@ -575,12 +563,6 @@ export async function deleteDryingTimer(id: string): Promise<void> {
 
 // ── Annotations ──────────────────────────────────────────────────────────────
 
-export async function getAnnotations(stepId: string): Promise<Annotation[] | null> {
-  const result = await invoke<StepAnnotations | null>("get_annotations", { stepId });
-  if (!result) return null;
-  return JSON.parse(result.data) as Annotation[];
-}
-
 export async function saveAnnotations(stepId: string, annotations: Annotation[]): Promise<void> {
   await invoke<StepAnnotations>("save_annotations", { stepId, data: JSON.stringify(annotations) });
 }
@@ -728,10 +710,6 @@ export async function getNextSprueColor(projectId: string): Promise<string> {
 
 // ── Step Sprue Parts ────────────────────────────────────────────────────────
 
-export async function listStepSprueParts(stepId: string): Promise<StepSpruePart[]> {
-  return invoke<StepSpruePart[]>("list_step_sprue_parts", { stepId });
-}
-
 export async function listProjectSprueParts(projectId: string): Promise<StepSpruePart[]> {
   return invoke<StepSpruePart[]>("list_project_sprue_parts", { projectId });
 }
@@ -768,14 +746,7 @@ export async function sprueDepletionSummary(projectId: string): Promise<SprueDep
 
 // ── Step Context ────────────────────────────────────────────────────────────
 
-interface RawStepContext {
-  tags: StepContext["tags"];
-  relations: StepContext["relations"];
-  paint_refs: StepContext["paint_refs"];
-  sprue_parts: StepContext["sprue_parts"];
-  reference_images: StepContext["reference_images"];
-  annotations: StepAnnotations | null;
-}
+type RawStepContext = Omit<StepContext, "annotations"> & { annotations: StepAnnotations | null };
 
 export async function getStepContext(stepId: string): Promise<StepContext> {
   const raw = await invoke<RawStepContext>("get_step_context", { stepId });

--- a/src/components/build/AnnotationLayer.tsx
+++ b/src/components/build/AnnotationLayer.tsx
@@ -35,7 +35,7 @@ function toLayerX(nx: number, w: number) { return nx * w; }
 function toLayerY(ny: number, h: number) { return ny * h; }
 
 export function AnnotationLayer({ stepId, effectiveW, effectiveH, zoom, drawPreview, previewColor }: AnnotationLayerProps) {
-  const annotations = useAppStore((s) => s.stepAnnotations[stepId] ?? EMPTY_ANNOTATIONS);
+  const annotations = useAppStore((s) => s.stepContexts[stepId]?.annotations ?? EMPTY_ANNOTATIONS);
   const annotationMode = useAppStore((s) => s.annotationMode);
   const removeAnnotation = useAppStore((s) => s.removeAnnotation);
   const { accent: SELECTION_COLOR } = useTheme();

--- a/src/components/build/AnnotationToolbar.tsx
+++ b/src/components/build/AnnotationToolbar.tsx
@@ -43,7 +43,7 @@ export function AnnotationToolbar() {
   const annotationStrokeWidth = useAppStore((s) => s.annotationStrokeWidth);
   const setAnnotationStrokeWidth = useAppStore((s) => s.setAnnotationStrokeWidth);
   const activeStepId = useAppStore((s) => s.activeStepId);
-  const annotations = useAppStore((s) => s.activeStepId ? (s.stepAnnotations[s.activeStepId] ?? EMPTY_ANNOTATIONS) : EMPTY_ANNOTATIONS);
+  const annotations = useAppStore((s) => s.activeStepId ? (s.stepContexts[s.activeStepId]?.annotations ?? EMPTY_ANNOTATIONS) : EMPTY_ANNOTATIONS);
   const clearAnnotations = useAppStore((s) => s.clearAnnotations);
   const undoAnnotation = useAppStore((s) => s.undoAnnotation);
   const redoAnnotation = useAppStore((s) => s.redoAnnotation);

--- a/src/components/build/BuildingStepPanel.tsx
+++ b/src/components/build/BuildingStepPanel.tsx
@@ -41,34 +41,21 @@ export function BuildingStepPanel() {
   const requestStepCompletion = useAppStore((s) => s.requestStepCompletion);
   const loadTracks = useAppStore((s) => s.loadTracks);
   const activeProjectId = useAppStore((s) => s.activeProjectId);
-  const stepTags = useAppStore((s) => s.stepTags);
-  const loadStepTags = useAppStore((s) => s.loadStepTags);
-  const stepRelations = useAppStore((s) => s.stepRelations);
-  const loadStepRelations = useAppStore((s) => s.loadStepRelations);
+  const stepContexts = useAppStore((s) => s.stepContexts);
+  const loadStepContext = useAppStore((s) => s.loadStepContext);
   const projectPaletteEntries = useAppStore((s) => s.projectPaletteEntries);
-  const stepPaintRefs = useAppStore((s) => s.stepPaintRefs);
-  const loadStepPaintRefs = useAppStore((s) => s.loadStepPaintRefs);
-  const stepReferenceImages = useAppStore((s) => s.stepReferenceImages);
-  const loadStepReferenceImages = useAppStore((s) => s.loadStepReferenceImages);
   const addReferenceImageStore = useAppStore((s) => s.addReferenceImageStore);
   const sprueRefs = useAppStore((s) => s.sprueRefs);
-  const stepSprueParts = useAppStore((s) => s.stepSprueParts);
-  const loadStepSprueParts = useAppStore((s) => s.loadStepSprueParts);
 
   const step = activeStepId ? steps.find((s) => s.id === activeStepId) ?? null : null;
   const track = step ? tracks.find((t) => t.id === step.track_id) : null;
+  const ctx = step ? stepContexts[step.id] : undefined;
 
-  // Load tags, relations, reference images when step changes
+  // Load step context when step changes
   useEffect(() => {
     if (!step) return;
-    const loads: Promise<void>[] = [];
-    if (!stepTags[step.id]) loads.push(loadStepTags(step.id));
-    if (!stepPaintRefs[step.id]) loads.push(loadStepPaintRefs(step.id));
-    if (!stepRelations[step.id]) loads.push(loadStepRelations(step.id));
-    if (!stepReferenceImages[step.id]) loads.push(loadStepReferenceImages(step.id));
-    if (!stepSprueParts[step.id]) loads.push(loadStepSprueParts(step.id));
-    if (loads.length > 0) {
-      Promise.all(loads).catch((e) => toast.error(`Failed to load step data: ${e}`));
+    if (!stepContexts[step.id]) {
+      loadStepContext(step.id).catch((e) => toast.error(`Failed to load step data: ${e}`));
     }
   }, [step?.id]);
 
@@ -99,9 +86,9 @@ export function BuildingStepPanel() {
 
   if (!step) return null;
 
-  const currentTags = stepTags[step.id] ?? [];
-  const currentRelations = stepRelations[step.id] ?? [];
-  const referenceImages = stepReferenceImages[step.id] ?? [];
+  const currentTags = ctx?.tags ?? [];
+  const currentRelations = ctx?.relations ?? [];
+  const referenceImages = ctx?.reference_images ?? [];
 
   const { blockedByIds, blocksAccessIds, incomingBlockedBy, incomingBlocksAccess } =
     parseStepRelations(currentRelations, step.id);

--- a/src/components/build/CompletionWarningDialog.tsx
+++ b/src/components/build/CompletionWarningDialog.tsx
@@ -11,14 +11,14 @@ export function CompletionWarningDialog() {
   const requestStepCompletion = useAppStore((s) => s.requestStepCompletion);
   const steps = useAppStore((s) => s.steps);
   const tracks = useAppStore((s) => s.tracks);
-  const stepRelations = useAppStore((s) => s.stepRelations);
+  const stepContexts = useAppStore((s) => s.stepContexts);
 
   // Re-derive warnings from current steps state so inline completions update the dialog
   const liveWarnings = useMemo(() => {
     if (!pendingCompletion) return null;
-    const relations = stepRelations[pendingCompletion.stepId] ?? [];
+    const relations = stepContexts[pendingCompletion.stepId]?.relations ?? [];
     return getCompletionWarnings(pendingCompletion.stepId, steps, relations);
-  }, [pendingCompletion, steps, stepRelations]);
+  }, [pendingCompletion, steps, stepContexts]);
 
   if (!pendingCompletion || !liveWarnings) return null;
 

--- a/src/components/build/PageInfoPanel.tsx
+++ b/src/components/build/PageInfoPanel.tsx
@@ -29,14 +29,9 @@ export function PageInfoPanel() {
   const loadTracks = useAppStore((s) => s.loadTracks);
   const activeProjectId = useAppStore((s) => s.activeProjectId);
 
-  // Lazy-load caches
-  const stepSprueParts = useAppStore((s) => s.stepSprueParts);
-  const loadStepSprueParts = useAppStore((s) => s.loadStepSprueParts);
+  const stepContexts = useAppStore((s) => s.stepContexts);
+  const loadStepContext = useAppStore((s) => s.loadStepContext);
   const setSpruePartTicked = useAppStore((s) => s.setSpruePartTicked);
-  const stepPaintRefs = useAppStore((s) => s.stepPaintRefs);
-  const loadStepPaintRefs = useAppStore((s) => s.loadStepPaintRefs);
-  const stepRelations = useAppStore((s) => s.stepRelations);
-  const loadStepRelations = useAppStore((s) => s.loadStepRelations);
   const projectPaletteEntries = useAppStore((s) => s.projectPaletteEntries);
   const sprueRefs = useAppStore((s) => s.sprueRefs);
 
@@ -87,13 +82,11 @@ export function PageInfoPanel() {
     }
   }, [pageId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Lazy load data for steps on this page
+  // Lazy load context for steps on this page
   useEffect(() => {
     if (!pageId) return;
     for (const step of pageSteps) {
-      if (!stepSprueParts[step.id]) loadStepSprueParts(step.id);
-      if (!stepPaintRefs[step.id]) loadStepPaintRefs(step.id);
-      if (!stepRelations[step.id]) loadStepRelations(step.id);
+      if (!stepContexts[step.id]) loadStepContext(step.id);
     }
   }, [pageId, pageSteps.length]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -109,12 +102,12 @@ export function PageInfoPanel() {
   const allParts = useMemo((): (StepSpruePart & { _stepId: string })[] => {
     const parts: (StepSpruePart & { _stepId: string })[] = [];
     for (const step of pageSteps) {
-      for (const p of stepSprueParts[step.id] ?? []) {
+      for (const p of stepContexts[step.id]?.sprue_parts ?? []) {
         parts.push({ ...p, _stepId: step.id });
       }
     }
     return parts;
-  }, [stepSprueParts, pageSteps]);
+  }, [stepContexts, pageSteps]);
 
   const partStats = useMemo(() => {
     const total = allParts.reduce((sum, p) => sum + p.quantity, 0);
@@ -131,12 +124,12 @@ export function PageInfoPanel() {
   const pagePaints = useMemo(() => {
     const ids = new Set<string>();
     for (const step of pageSteps) {
-      for (const id of stepPaintRefs[step.id] ?? []) {
+      for (const id of stepContexts[step.id]?.paint_refs ?? []) {
         ids.add(id);
       }
     }
     return projectPaletteEntries.filter((e) => ids.has(e.id));
-  }, [pageSteps, stepPaintRefs, projectPaletteEntries]);
+  }, [pageSteps, stepContexts, projectPaletteEntries]);
 
   const refMap = useMemo(
     () => new Map(sprueRefs.map((r) => [r.label, r])),
@@ -266,8 +259,8 @@ export function PageInfoPanel() {
                             const children = childrenMap.get(step.id) ?? [];
                             const isStepExpanded = expandedStepIds.has(step.id);
                             const isActive = step.id === activeStepId;
-                            const rels = stepRelations[step.id]
-                              ? parseStepRelations(stepRelations[step.id], step.id)
+                            const rels = stepContexts[step.id]?.relations
+                              ? parseStepRelations(stepContexts[step.id].relations, step.id)
                               : null;
 
                             return (

--- a/src/components/build/PaintRefChips.tsx
+++ b/src/components/build/PaintRefChips.tsx
@@ -15,12 +15,12 @@ interface PaintRefChipsProps {
 }
 
 export function PaintRefChips({ stepId, showLabel = false }: PaintRefChipsProps) {
-  const stepPaintRefs = useAppStore((s) => s.stepPaintRefs);
+  const stepContexts = useAppStore((s) => s.stepContexts);
   const setStepPaintRefsAction = useAppStore((s) => s.setStepPaintRefs);
   const projectPaletteEntries = useAppStore((s) => s.projectPaletteEntries);
   const [open, setOpen] = useState(false);
 
-  const currentIds = stepPaintRefs[stepId] ?? [];
+  const currentIds = stepContexts[stepId]?.paint_refs ?? [];
   const currentIdSet = useMemo(() => new Set(currentIds), [currentIds]);
 
   const currentEntries = useMemo(

--- a/src/components/build/PartChipEditor.tsx
+++ b/src/components/build/PartChipEditor.tsx
@@ -55,7 +55,7 @@ function parsePartInput(
 
 export function PartChipEditor({ stepId, readOnly = false, buildMode = false }: PartChipEditorProps) {
   const sprueRefs = useAppStore((s) => s.sprueRefs);
-  const stepSprueParts = useAppStore((s) => s.stepSprueParts);
+  const stepContexts = useAppStore((s) => s.stepContexts);
   const addStepSpruePartStore = useAppStore((s) => s.addStepSpruePartStore);
   const removeStepSpruePartStore = useAppStore((s) => s.removeStepSpruePartStore);
   const setSpruePartTicked = useAppStore((s) => s.setSpruePartTicked);
@@ -68,7 +68,7 @@ export function PartChipEditor({ stepId, readOnly = false, buildMode = false }: 
   const inputRef = useRef<HTMLInputElement>(null);
   const [lightboxLabel, setLightboxLabel] = useState<string | null>(null);
 
-  const currentParts = stepSprueParts[stepId] ?? [];
+  const currentParts = stepContexts[stepId]?.sprue_parts ?? [];
 
   const grouped = useMemo(() => groupPartsBySprue(currentParts), [currentParts]);
 

--- a/src/components/build/RelationPill.tsx
+++ b/src/components/build/RelationPill.tsx
@@ -5,12 +5,12 @@ import { parseStepRelations } from "./tree-utils";
 export function RelationPill() {
   const activeStepId = useAppStore((s) => s.activeStepId);
   const steps = useAppStore((s) => s.steps);
-  const stepRelations = useAppStore((s) => s.stepRelations);
+  const stepContexts = useAppStore((s) => s.stepContexts);
   const setActiveStep = useAppStore((s) => s.setActiveStep);
 
   const [visible, setVisible] = useState(false);
 
-  const relations = activeStepId ? stepRelations[activeStepId] ?? [] : [];
+  const relations = activeStepId ? stepContexts[activeStepId]?.relations ?? [] : [];
   const blockedByIds = useMemo(
     () => activeStepId ? parseStepRelations(relations, activeStepId).blockedByIds : [],
     [relations, activeStepId],

--- a/src/components/build/SpruePanel.tsx
+++ b/src/components/build/SpruePanel.tsx
@@ -15,7 +15,7 @@ export function SpruePanel() {
   const spruePanelOpen = useAppStore((s) => s.spruePanelOpen);
   const toggleSpruePanel = useAppStore((s) => s.toggleSpruePanel);
   const activeStepId = useAppStore((s) => s.activeStepId);
-  const activeStepParts = useAppStore((s) => s.activeStepId ? s.stepSprueParts[s.activeStepId] ?? EMPTY_PARTS : EMPTY_PARTS);
+  const activeStepParts = useAppStore((s) => s.activeStepId ? s.stepContexts[s.activeStepId]?.sprue_parts ?? EMPTY_PARTS : EMPTY_PARTS);
 
   const [lightboxLabel, setLightboxLabel] = useState<string | null>(null);
 

--- a/src/components/build/StepEditorPanel.tsx
+++ b/src/components/build/StepEditorPanel.tsx
@@ -51,23 +51,16 @@ export function StepEditorPanel() {
   const addStep = useAppStore((s) => s.addStep);
   const loadTracks = useAppStore((s) => s.loadTracks);
   const loadSteps = useAppStore((s) => s.loadSteps);
-  const stepTags = useAppStore((s) => s.stepTags);
-  const loadStepTags = useAppStore((s) => s.loadStepTags);
+  const stepContexts = useAppStore((s) => s.stepContexts);
+  const loadStepContext = useAppStore((s) => s.loadStepContext);
+  const invalidateStepContext = useAppStore((s) => s.invalidateStepContext);
   const setStepTagsAction = useAppStore((s) => s.setStepTags);
-  const stepRelations = useAppStore((s) => s.stepRelations);
-  const loadStepRelations = useAppStore((s) => s.loadStepRelations);
   const setStepRelationsAction = useAppStore((s) => s.setStepRelations);
   const projectPaletteEntries = useAppStore((s) => s.projectPaletteEntries);
-  const stepPaintRefs = useAppStore((s) => s.stepPaintRefs);
-  const loadStepPaintRefs = useAppStore((s) => s.loadStepPaintRefs);
-  const stepReferenceImages = useAppStore((s) => s.stepReferenceImages);
-  const loadStepReferenceImages = useAppStore((s) => s.loadStepReferenceImages);
   const addReferenceImageStore = useAppStore((s) => s.addReferenceImageStore);
   const updateReferenceImageStore = useAppStore((s) => s.updateReferenceImageStore);
   const removeReferenceImageStore = useAppStore((s) => s.removeReferenceImageStore);
   const sprueRefs = useAppStore((s) => s.sprueRefs);
-  const stepSprueParts = useAppStore((s) => s.stepSprueParts);
-  const loadStepSprueParts = useAppStore((s) => s.loadStepSprueParts);
 
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [tagPopoverOpen, setTagPopoverOpen] = useState(false);
@@ -81,15 +74,13 @@ export function StepEditorPanel() {
 
   const step = steps.find((s) => s.id === activeStepId);
 
-  // Load data and reset UI when step changes
+  const ctx = step ? stepContexts[step.id] : undefined;
+
+  // Load context and reset UI when step changes
   useEffect(() => {
     if (step) {
-      if (!stepTags[step.id]) loadStepTags(step.id);
-      if (!stepPaintRefs[step.id]) loadStepPaintRefs(step.id);
-      // Always reload relations (no cache check) because they can change from either side
-      loadStepRelations(step.id);
-      if (!stepReferenceImages[step.id]) loadStepReferenceImages(step.id);
-      if (!stepSprueParts[step.id]) loadStepSprueParts(step.id);
+      // Always reload context (relations can change from either side)
+      loadStepContext(step.id);
     }
     setExpandedImageId(null);
     setEditingCaptionId(null);
@@ -119,14 +110,14 @@ export function StepEditorPanel() {
 
   if (!step) return null;
 
-  const referenceImages = stepReferenceImages[step.id] ?? [];
+  const referenceImages = ctx?.reference_images ?? [];
   const expandedImage = expandedImageId
     ? referenceImages.find((i) => i.id === expandedImageId) ?? null
     : null;
-  const currentTags = stepTags[step.id] ?? [];
+  const currentTags = ctx?.tags ?? [];
   const currentTagNames = new Set(currentTags.map((t) => t.name));
 
-  const currentRelations = stepRelations[step.id] ?? [];
+  const currentRelations = ctx?.relations ?? [];
   const { blockedByIds, blocksAccessIds, incomingBlockedBy, incomingBlocksAccess } =
     parseStepRelations(currentRelations, step.id);
 
@@ -169,13 +160,13 @@ export function StepEditorPanel() {
       ...otherIds.map((id) => ({ target_step_id: id, relation_type: otherType })),
     ];
     await setStepRelationsAction(step.id, relations);
-    // Invalidate the target step's cached relations so it reflects the change
-    loadStepRelations(targetStepId);
+    // Invalidate the target step's cached context so it reflects the change
+    invalidateStepContext(targetStepId);
   };
 
   /** Toggle a relation on another step that points back to this step. */
   const handleToggleIncomingRelation = async (otherStepId: string, relationType: StepRelationType) => {
-    const ownerRelations = stepRelations[otherStepId] ?? await api.listStepRelations(otherStepId);
+    const ownerRelations = stepContexts[otherStepId]?.relations ?? await api.listStepRelations(otherStepId);
     const outgoing = ownerRelations.filter((r) => r.from_step_id === otherStepId);
     const exists = outgoing.some((r) => r.to_step_id === step.id && r.relation_type === relationType);
 
@@ -190,8 +181,8 @@ export function StepEditorPanel() {
       otherStepId,
       updated.map((r) => ({ target_step_id: r.to_step_id, relation_type: r.relation_type })),
     );
-    loadStepRelations(step.id);
-    loadStepRelations(otherStepId);
+    invalidateStepContext(step.id);
+    invalidateStepContext(otherStepId);
   };
 
   const handleSetReplaces = async (targetStepId: string | null) => {

--- a/src/components/build/StepThumbnail.tsx
+++ b/src/components/build/StepThumbnail.tsx
@@ -35,7 +35,7 @@ interface StepThumbnailProps {
 export function StepThumbnail({ step, page, isActive, isCompleted }: StepThumbnailProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [size, setSize] = useState({ w: THUMB_H, h: THUMB_H });
-  const annotations = useAppStore((s) => s.stepAnnotations[step.id]);
+  const annotations = useAppStore((s) => s.stepContexts[step.id]?.annotations);
 
   const hasCrop =
     step.crop_x != null &&

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -881,6 +881,16 @@ export interface BackupDiff {
   photos: number;
 }
 
+// ── Step Context (bundled per-step data) ────────────────────────────────
+export interface StepContext {
+  tags: Tag[];
+  relations: StepRelation[];
+  paint_refs: string[];
+  sprue_parts: StepSpruePart[];
+  reference_images: ReferenceImage[];
+  annotations: Annotation[];
+}
+
 // ── Settings Defaults ───────────────────────────────────────────────────
 export const SETTINGS_DEFAULTS: Record<string, string> = {
   theme: "default",

--- a/src/store/build-slice.ts
+++ b/src/store/build-slice.ts
@@ -24,6 +24,7 @@ function polygonBoundingBox(points: { x: number; y: number }[]) {
 /** Fire-and-forget AI part detection for a step. Updates store on completion. */
 function runDetection(
   set: (partial: Partial<AppStore> | ((s: AppStore) => Partial<AppStore>)) => void,
+  get: () => AppStore,
   stepId: string,
 ) {
   api.detectStepSprues(stepId).then((result) => {
@@ -31,16 +32,17 @@ function runDetection(
       const ctx = s.stepContexts[stepId];
       return {
         steps: s.steps.map((st) => st.id === stepId ? { ...st, sprues_detected: true } : st),
-        ...(result.parts.length > 0 ? {
-          stepContexts: ctx ? {
+        ...(result.parts.length > 0 && ctx ? {
+          stepContexts: {
             ...s.stepContexts,
             [stepId]: { ...ctx, sprue_parts: [...ctx.sprue_parts, ...result.parts] },
-          } : s.stepContexts,
-          projectSprueParts: [...s.projectSprueParts, ...result.parts],
+          },
         } : {}),
       };
     });
     if (result.parts.length > 0) {
+      const projectId = get().activeProjectId;
+      if (projectId) get().loadProjectSprueParts(projectId);
       toast.success(`Detected ${result.parts.length} part${result.parts.length === 1 ? "" : "s"}`, { toasterId: "canvas" });
     }
   }).catch((err) => {
@@ -740,9 +742,11 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
           ...s.stepContexts,
           [part.step_id]: { ...ctx, sprue_parts: [...ctx.sprue_parts, part] },
         } : s.stepContexts,
-        projectSprueParts: [...s.projectSprueParts, part],
       };
     });
+    // Refresh project-level cache
+    const projectId = get().activeProjectId;
+    if (projectId) get().loadProjectSprueParts(projectId);
   },
 
   removeStepSpruePartStore: (stepId, id) => {
@@ -753,9 +757,10 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
           ...s.stepContexts,
           [stepId]: { ...ctx, sprue_parts: ctx.sprue_parts.filter((p) => p.id !== id) },
         } : s.stepContexts,
-        projectSprueParts: s.projectSprueParts.filter((p) => p.id !== id),
       };
     });
+    const projectId = get().activeProjectId;
+    if (projectId) get().loadProjectSprueParts(projectId);
   },
 
   setSpruePartTicked: (stepId, partId, tickedCount) => {
@@ -773,10 +778,13 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
           ...s.stepContexts,
           [stepId]: { ...c, sprue_parts: c.sprue_parts.map(mapPart) },
         } : s.stepContexts,
-        projectSprueParts: s.projectSprueParts.map(mapPart),
       };
     });
-    api.setSpruePartTicked(partId, tickedCount).catch(() => {
+    api.setSpruePartTicked(partId, tickedCount).then(() => {
+      // Refresh project-level cache after successful persist
+      const projectId = get().activeProjectId;
+      if (projectId) get().loadProjectSprueParts(projectId);
+    }).catch(() => {
       set((s) => {
         const c = s.stepContexts[stepId];
         return {
@@ -784,7 +792,6 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
             ...s.stepContexts,
             [stepId]: { ...c, sprue_parts: c.sprue_parts.map(rollbackPart) },
           } : s.stepContexts,
-          projectSprueParts: s.projectSprueParts.map(rollbackPart),
         };
       });
     });
@@ -1413,7 +1420,7 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
     const apiKey = settings.ai_api_key ?? "";
     if (!autoDetect || !apiKey) return;
 
-    runDetection(set, stepId);
+    runDetection(set, get, stepId);
   },
 
   redetectStepSprues: async (stepId) => {
@@ -1428,18 +1435,18 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
       set((s) => {
         const ctx = s.stepContexts[stepId];
         const stepParts = ctx?.sprue_parts ?? [];
-        const aiPartIds = new Set(stepParts.filter((p) => p.ai_detected).map((p) => p.id));
         return {
           stepContexts: ctx ? {
             ...s.stepContexts,
             [stepId]: { ...ctx, sprue_parts: stepParts.filter((p) => !p.ai_detected) },
           } : s.stepContexts,
-          projectSprueParts: s.projectSprueParts.filter((p) => !aiPartIds.has(p.id)),
           steps: s.steps.map((st) => st.id === stepId ? { ...st, sprues_detected: false } : st),
         };
       });
+      const projectId = get().activeProjectId;
+      if (projectId) get().loadProjectSprueParts(projectId);
       // Force re-run detection (bypass auto-detect setting)
-      runDetection(set, stepId);
+      runDetection(set, get, stepId);
     } catch (err) {
       toast.error(`Re-detect failed: ${err}`);
     }

--- a/src/store/build-slice.ts
+++ b/src/store/build-slice.ts
@@ -465,10 +465,9 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
     } else {
       set({ activeTrackId: null });
     }
-    // Persist to DB (fire-and-forget)
     const projectId = get().activeProjectId;
     if (projectId) {
-      api.saveActiveTrack(projectId, id);
+      api.saveActiveTrack(projectId, id).catch((e) => toast.error(`Failed to save active track: ${e}`));
     }
   },
 
@@ -577,9 +576,8 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
           }
         }
         set(update);
-        // Persist track change to DB
         if (trackChanged && state.activeProjectId) {
-          api.saveActiveTrack(state.activeProjectId, step.track_id);
+          api.saveActiveTrack(state.activeProjectId, step.track_id).catch((e) => toast.error(`Failed to save active track: ${e}`));
         }
       } else {
         set({ activeStepId: id });
@@ -841,7 +839,9 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
         timers.delete(stepId);
         const annotations = get().stepContexts[stepId]?.annotations;
         if (annotations) {
-          api.saveAnnotations(stepId, annotations).catch(() => {});
+          api.saveAnnotations(stepId, annotations).catch((e) => {
+            toast.error(`Failed to save annotations: ${e}`);
+          });
         }
       }, 500));
     };
@@ -902,11 +902,11 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
   setAnnotationMode: (mode) => set({ annotationMode: mode }),
   setAnnotationColor: (color) => {
     set({ annotationColor: color });
-    api.setSetting("annotation_color", color).catch(() => {});
+    api.setSetting("annotation_color", color).catch((e) => toast.error(`Failed to save setting: ${e}`));
   },
   setAnnotationStrokeWidth: (width) => {
     set({ annotationStrokeWidth: width });
-    api.setSetting("annotation_stroke_width", String(width)).catch(() => {});
+    api.setSetting("annotation_stroke_width", String(width)).catch((e) => toast.error(`Failed to save setting: ${e}`));
   },
 
   undoAnnotation: (stepId) => {
@@ -1080,7 +1080,7 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
             entryType: "step_complete",
             stepId: step.id,
             trackId: step.track_id,
-          }).catch(() => {});
+          }).catch((e) => toast.error(`Failed to log step completion: ${e}`));
         }
 
         // Auto-start drying timer if step has adhesive/drying time
@@ -1095,7 +1095,7 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
               },
               duration: 5000,
             });
-          }).catch(() => {});
+          }).catch((e) => toast.error(`Failed to start timer: ${e}`));
         }
 
         // Check for milestone: track fully complete
@@ -1110,7 +1110,7 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
               trackId: track.id,
               isTrackCompletion: true,
               trackStepCount: track.step_count,
-            }).catch(() => {});
+            }).catch((e) => toast.error(`Failed to log milestone: ${e}`));
           }
           set({
             pendingMilestone: { trackId: track.id, trackName: track.name, trackColor: track.color },
@@ -1252,7 +1252,7 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
     set({ spruePanelOpen: open });
     const projectId = get().activeProjectId;
     if (projectId) {
-      api.saveSpruePanel(projectId, open).catch(() => {});
+      api.saveSpruePanel(projectId, open).catch((e) => toast.error(`Failed to save panel state: ${e}`));
     }
   },
 

--- a/src/store/build-slice.ts
+++ b/src/store/build-slice.ts
@@ -673,6 +673,7 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
       const { [stepId]: _, ...rest } = s.stepContexts;
       return { stepContexts: rest };
     });
+    get().loadStepContext(stepId);
   },
 
   setStepTags: async (stepId, tagNames) => {
@@ -833,54 +834,58 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
   })(),
 
   addAnnotation: (stepId, annotation) => {
-    const ctx = get().stepContexts[stepId];
-    if (!ctx) return;
-    const current = ctx.annotations;
-    set((s) => ({
-      stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: [...current, annotation] } },
-      ...annotationUndoSnapshot(s, stepId, current),
-    }));
+    set((s) => {
+      const ctx = s.stepContexts[stepId];
+      if (!ctx) return {};
+      return {
+        stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: [...ctx.annotations, annotation] } },
+        ...annotationUndoSnapshot(s, stepId, ctx.annotations),
+      };
+    });
     get().saveAnnotationsDebounced(stepId);
   },
 
   removeAnnotation: (stepId, annotationId) => {
-    const ctx = get().stepContexts[stepId];
-    if (!ctx) return;
-    const current = ctx.annotations;
-    set((s) => ({
-      stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: current.filter((a) => a.id !== annotationId) } },
-      ...annotationUndoSnapshot(s, stepId, current),
-    }));
+    set((s) => {
+      const ctx = s.stepContexts[stepId];
+      if (!ctx) return {};
+      return {
+        stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: ctx.annotations.filter((a) => a.id !== annotationId) } },
+        ...annotationUndoSnapshot(s, stepId, ctx.annotations),
+      };
+    });
     get().saveAnnotationsDebounced(stepId);
   },
 
   clearAnnotations: (stepId) => {
-    const ctx = get().stepContexts[stepId];
-    if (!ctx || ctx.annotations.length === 0) return;
-    const current = ctx.annotations;
-    set((s) => ({
-      stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: [] } },
-      ...annotationUndoSnapshot(s, stepId, current),
-    }));
+    set((s) => {
+      const ctx = s.stepContexts[stepId];
+      if (!ctx || ctx.annotations.length === 0) return {};
+      return {
+        stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: [] } },
+        ...annotationUndoSnapshot(s, stepId, ctx.annotations),
+      };
+    });
     get().saveAnnotationsDebounced(stepId);
   },
 
   updateAnnotation: (stepId, annotationId, updates) => {
-    const ctx = get().stepContexts[stepId];
-    if (!ctx) return;
-    const current = ctx.annotations;
-    set((s) => ({
-      stepContexts: {
-        ...s.stepContexts,
-        [stepId]: {
-          ...ctx,
-          annotations: current.map((a) =>
-            a.id === annotationId ? { ...a, ...updates } as Annotation : a,
-          ),
+    set((s) => {
+      const ctx = s.stepContexts[stepId];
+      if (!ctx) return {};
+      return {
+        stepContexts: {
+          ...s.stepContexts,
+          [stepId]: {
+            ...ctx,
+            annotations: ctx.annotations.map((a) =>
+              a.id === annotationId ? { ...a, ...updates } as Annotation : a,
+            ),
+          },
         },
-      },
-      ...annotationUndoSnapshot(s, stepId, current),
-    }));
+        ...annotationUndoSnapshot(s, stepId, ctx.annotations),
+      };
+    });
     get().saveAnnotationsDebounced(stepId);
   },
 
@@ -895,44 +900,34 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
   },
 
   undoAnnotation: (stepId) => {
-    const undoStack = get().annotationUndoStacks[stepId] ?? [];
-    if (undoStack.length === 0) return;
-    const ctx = get().stepContexts[stepId];
-    if (!ctx) return;
-    const current = ctx.annotations;
-    const previous = undoStack[undoStack.length - 1];
-    set((s) => ({
-      stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: previous } },
-      annotationUndoStacks: {
-        ...s.annotationUndoStacks,
-        [stepId]: undoStack.slice(0, -1),
-      },
-      annotationRedoStacks: {
-        ...s.annotationRedoStacks,
-        [stepId]: [...(s.annotationRedoStacks[stepId] ?? []), current],
-      },
-    }));
+    set((s) => {
+      const stack = s.annotationUndoStacks[stepId] ?? [];
+      if (stack.length === 0) return {};
+      const ctx = s.stepContexts[stepId];
+      if (!ctx) return {};
+      const previous = stack[stack.length - 1];
+      return {
+        stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: previous } },
+        annotationUndoStacks: { ...s.annotationUndoStacks, [stepId]: stack.slice(0, -1) },
+        annotationRedoStacks: { ...s.annotationRedoStacks, [stepId]: [...(s.annotationRedoStacks[stepId] ?? []), ctx.annotations] },
+      };
+    });
     get().saveAnnotationsDebounced(stepId);
   },
 
   redoAnnotation: (stepId) => {
-    const redoStack = get().annotationRedoStacks[stepId] ?? [];
-    if (redoStack.length === 0) return;
-    const ctx = get().stepContexts[stepId];
-    if (!ctx) return;
-    const current = ctx.annotations;
-    const next = redoStack[redoStack.length - 1];
-    set((s) => ({
-      stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: next } },
-      annotationRedoStacks: {
-        ...s.annotationRedoStacks,
-        [stepId]: redoStack.slice(0, -1),
-      },
-      annotationUndoStacks: {
-        ...s.annotationUndoStacks,
-        [stepId]: [...(s.annotationUndoStacks[stepId] ?? []), current],
-      },
-    }));
+    set((s) => {
+      const stack = s.annotationRedoStacks[stepId] ?? [];
+      if (stack.length === 0) return {};
+      const ctx = s.stepContexts[stepId];
+      if (!ctx) return {};
+      const next = stack[stack.length - 1];
+      return {
+        stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: next } },
+        annotationRedoStacks: { ...s.annotationRedoStacks, [stepId]: stack.slice(0, -1) },
+        annotationUndoStacks: { ...s.annotationUndoStacks, [stepId]: [...(s.annotationUndoStacks[stepId] ?? []), ctx.annotations] },
+      };
+    });
     get().saveAnnotationsDebounced(stepId);
   },
   loadInstructionSources: async (projectId) => {

--- a/src/store/build-slice.ts
+++ b/src/store/build-slice.ts
@@ -735,12 +735,8 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
   addStepSpruePartStore: (part) => {
     set((s) => {
       const ctx = s.stepContexts[part.step_id];
-      return {
-        stepContexts: ctx ? {
-          ...s.stepContexts,
-          [part.step_id]: { ...ctx, sprue_parts: [...ctx.sprue_parts, part] },
-        } : s.stepContexts,
-      };
+      if (!ctx) return {};
+      return { stepContexts: { ...s.stepContexts, [part.step_id]: { ...ctx, sprue_parts: [...ctx.sprue_parts, part] } } };
     });
     // Refresh project-level cache
     const projectId = get().activeProjectId;
@@ -750,12 +746,8 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
   removeStepSpruePartStore: (stepId, id) => {
     set((s) => {
       const ctx = s.stepContexts[stepId];
-      return {
-        stepContexts: ctx ? {
-          ...s.stepContexts,
-          [stepId]: { ...ctx, sprue_parts: ctx.sprue_parts.filter((p) => p.id !== id) },
-        } : s.stepContexts,
-      };
+      if (!ctx) return {};
+      return { stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, sprue_parts: ctx.sprue_parts.filter((p) => p.id !== id) } } };
     });
     const projectId = get().activeProjectId;
     if (projectId) get().loadProjectSprueParts(projectId);
@@ -771,26 +763,19 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
       p.id === partId ? { ...p, ticked_count: prev } : p;
     set((s) => {
       const c = s.stepContexts[stepId];
-      return {
-        stepContexts: c ? {
-          ...s.stepContexts,
-          [stepId]: { ...c, sprue_parts: c.sprue_parts.map(mapPart) },
-        } : s.stepContexts,
-      };
+      if (!c) return {};
+      return { stepContexts: { ...s.stepContexts, [stepId]: { ...c, sprue_parts: c.sprue_parts.map(mapPart) } } };
     });
     api.setSpruePartTicked(partId, tickedCount).then(() => {
       // Refresh project-level cache after successful persist
       const projectId = get().activeProjectId;
       if (projectId) get().loadProjectSprueParts(projectId);
-    }).catch(() => {
+    }).catch((e) => {
+      toast.error(`Failed to update part: ${e}`);
       set((s) => {
         const c = s.stepContexts[stepId];
-        return {
-          stepContexts: c ? {
-            ...s.stepContexts,
-            [stepId]: { ...c, sprue_parts: c.sprue_parts.map(rollbackPart) },
-          } : s.stepContexts,
-        };
+        if (!c) return {};
+        return { stepContexts: { ...s.stepContexts, [stepId]: { ...c, sprue_parts: c.sprue_parts.map(rollbackPart) } } };
       });
     });
   },
@@ -1434,13 +1419,11 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
       await api.redetectStepSprues(stepId);
       set((s) => {
         const ctx = s.stepContexts[stepId];
-        const stepParts = ctx?.sprue_parts ?? [];
         return {
-          stepContexts: ctx ? {
-            ...s.stepContexts,
-            [stepId]: { ...ctx, sprue_parts: stepParts.filter((p) => !p.ai_detected) },
-          } : s.stepContexts,
           steps: s.steps.map((st) => st.id === stepId ? { ...st, sprues_detected: false } : st),
+          ...(ctx ? {
+            stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, sprue_parts: ctx.sprue_parts.filter((p) => !p.ai_detected) } },
+          } : {}),
         };
       });
       const projectId = get().activeProjectId;

--- a/src/store/build-slice.ts
+++ b/src/store/build-slice.ts
@@ -1,5 +1,5 @@
 import type { StateCreator } from "zustand";
-import type { Project, UpdateProjectInput, UpdateStepInput, InstructionSource, InstructionPage, Track, Step, Tag, StepRelation, ReferenceImage, Annotation, AnnotationTool, PaletteEntry, SprueRef, StepSpruePart } from "@/shared/types";
+import type { Project, UpdateProjectInput, UpdateStepInput, InstructionSource, InstructionPage, Track, Step, ReferenceImage, Annotation, AnnotationTool, PaletteEntry, SprueRef, StepSpruePart, StepContext } from "@/shared/types";
 import { getEffectiveDryingMinutes, ANNOTATION_TOOL_LABELS, getSettingBool } from "@/shared/types";
 import type { AppStore } from "./index";
 import * as api from "@/api";
@@ -27,16 +27,19 @@ function runDetection(
   stepId: string,
 ) {
   api.detectStepSprues(stepId).then((result) => {
-    set((s) => ({
-      steps: s.steps.map((st) => st.id === stepId ? { ...st, sprues_detected: true } : st),
-      ...(result.parts.length > 0 ? {
-        stepSprueParts: {
-          ...s.stepSprueParts,
-          [stepId]: [...(s.stepSprueParts[stepId] ?? []), ...result.parts],
-        },
-        projectSprueParts: [...s.projectSprueParts, ...result.parts],
-      } : {}),
-    }));
+    set((s) => {
+      const ctx = s.stepContexts[stepId];
+      return {
+        steps: s.steps.map((st) => st.id === stepId ? { ...st, sprues_detected: true } : st),
+        ...(result.parts.length > 0 ? {
+          stepContexts: ctx ? {
+            ...s.stepContexts,
+            [stepId]: { ...ctx, sprue_parts: [...ctx.sprue_parts, ...result.parts] },
+          } : s.stepContexts,
+          projectSprueParts: [...s.projectSprueParts, ...result.parts],
+        } : {}),
+      };
+    });
     if (result.parts.length > 0) {
       toast.success(`Detected ${result.parts.length} part${result.parts.length === 1 ? "" : "s"}`, { toasterId: "canvas" });
     }
@@ -111,21 +114,14 @@ export interface BuildSlice {
   shiftSelectSteps: (id: string) => void;
   clearSelectedSteps: () => void;
 
-  // Tags
-  stepTags: Record<string, Tag[]>;
-  loadStepTags: (stepId: string) => Promise<void>;
+  // Unified step context cache
+  stepContexts: Record<string, StepContext>;
+  loadStepContext: (stepId: string) => Promise<void>;
+  invalidateStepContext: (stepId: string) => void;
   setStepTags: (stepId: string, tagNames: string[]) => Promise<void>;
-
-  // Step relations
-  stepRelations: Record<string, StepRelation[]>;
-  loadStepRelations: (stepId: string) => Promise<void>;
   setStepRelations: (stepId: string, relations: { target_step_id: string; relation_type: string }[]) => Promise<void>;
-
-  // Step paint refs
-  stepPaintRefs: Record<string, string[]>;
-  projectPaletteEntries: PaletteEntry[];
-  loadStepPaintRefs: (stepId: string) => Promise<void>;
   setStepPaintRefs: (stepId: string, entryIds: string[]) => Promise<void>;
+  projectPaletteEntries: PaletteEntry[];
   refreshProjectPaletteEntries: () => Promise<void>;
 
   // Sprue refs (project-level)
@@ -137,18 +133,14 @@ export interface BuildSlice {
   updateSprueRefStore: (ref: SprueRef) => void;
   removeSprueRefStore: (id: string) => void;
 
-  // Step sprue parts (per-step + project-wide for badges)
-  stepSprueParts: Record<string, StepSpruePart[]>;
+  // Step sprue parts (project-wide for badges)
   projectSprueParts: StepSpruePart[];
-  loadStepSprueParts: (stepId: string) => Promise<void>;
   loadProjectSprueParts: (projectId: string) => Promise<void>;
   addStepSpruePartStore: (part: StepSpruePart) => void;
   removeStepSpruePartStore: (stepId: string, id: string) => void;
   setSpruePartTicked: (stepId: string, partId: string, tickedCount: number) => void;
 
   // Reference images
-  stepReferenceImages: Record<string, ReferenceImage[]>;
-  loadStepReferenceImages: (stepId: string) => Promise<void>;
   addReferenceImageStore: (img: ReferenceImage) => void;
   updateReferenceImageStore: (img: ReferenceImage) => void;
   removeReferenceImageStore: (stepId: string, id: string) => void;
@@ -157,8 +149,6 @@ export interface BuildSlice {
   annotationMode: AnnotationTool;
   annotationColor: string;
   annotationStrokeWidth: number;
-  stepAnnotations: Record<string, Annotation[]>;
-  loadAnnotations: (stepId: string) => Promise<void>;
   saveAnnotationsDebounced: (stepId: string) => void;
   addAnnotation: (stepId: string, annotation: Annotation) => void;
   removeAnnotation: (stepId: string, annotationId: string) => void;
@@ -274,16 +264,11 @@ const DEFAULT_BUILD_STATE = {
   selectedStepIds: [] as string[],
   selectionAnchorId: null as string | null,
   undoStack: [] as string[],
-  stepTags: {} as Record<string, Tag[]>,
-  stepPaintRefs: {} as Record<string, string[]>,
+  stepContexts: {} as Record<string, StepContext>,
   projectPaletteEntries: [] as PaletteEntry[],
   sprueRefs: [] as SprueRef[],
   activeSprueRefId: null as string | null,
-  stepSprueParts: {} as Record<string, StepSpruePart[]>,
   projectSprueParts: [] as StepSpruePart[],
-  stepRelations: {} as Record<string, StepRelation[]>,
-  stepReferenceImages: {} as Record<string, ReferenceImage[]>,
-  stepAnnotations: {} as Record<string, Annotation[]>,
   annotationMode: null as AnnotationTool,
   annotationColor: "#ef4444",
   annotationStrokeWidth: 0.003,
@@ -531,16 +516,9 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
 
   removeStep: (id) => {
     set((s) => {
-      // Clean up per-step cached data to prevent memory leaks
-      const { [id]: _tags, ...restTags } = s.stepTags;
-      const { [id]: _paintRefs, ...restPaintRefs } = s.stepPaintRefs;
-      const { [id]: _rels, ...restRelations } = s.stepRelations;
-      const { [id]: _refs, ...restReferenceImages } = s.stepReferenceImages;
-      const { [id]: _anns, ...restAnnotations } = s.stepAnnotations;
+      const { [id]: _ctx, ...restContexts } = s.stepContexts;
       const { [id]: _undo, ...restUndoStacks } = s.annotationUndoStacks;
       const { [id]: _redo, ...restRedoStacks } = s.annotationRedoStacks;
-      const { [id]: _sprueParts, ...restSprueParts } = s.stepSprueParts;
-      // Clear polygon draft and exit polygon mode if it references the deleted step
       const polygonCleanup = s.polygonDraftStepId === id
         ? { polygonDraftStepId: null, polygonDraftPoints: [] as { x: number; y: number }[], canvasMode: "view" as const }
         : {};
@@ -549,14 +527,9 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
         activeStepId: s.activeStepId === id ? null : s.activeStepId,
         selectedStepIds: s.selectedStepIds.filter((sid) => sid !== id),
         selectionAnchorId: s.selectionAnchorId === id ? null : s.selectionAnchorId,
-        stepTags: restTags,
-        stepPaintRefs: restPaintRefs,
-        stepRelations: restRelations,
-        stepReferenceImages: restReferenceImages,
-        stepAnnotations: restAnnotations,
+        stepContexts: restContexts,
         annotationUndoStacks: restUndoStacks,
         annotationRedoStacks: restRedoStacks,
-        stepSprueParts: restSprueParts,
         ...polygonCleanup,
       };
     });
@@ -592,9 +565,9 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
         // Reset viewer so CropCanvas re-centers on the new step
         if (state.buildMode === "building") {
           Object.assign(update, DEFAULT_VIEWER_STATE);
-          // Load annotations for building mode
-          if (step.crop_x != null && !state.stepAnnotations[step.id]) {
-            get().loadAnnotations(step.id);
+          // Load step context for building mode (includes annotations)
+          if (!state.stepContexts[step.id]) {
+            get().loadStepContext(step.id);
           }
           // Toast reminder when annotation tool persists across step change
           if (state.annotationMode && state.activeStepId && state.activeStepId !== id) {
@@ -690,14 +663,34 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
     }
   },
 
-  loadStepTags: async (stepId) => {
-    const tags = await api.listStepTags(stepId);
-    set((s) => ({ stepTags: { ...s.stepTags, [stepId]: tags } }));
+  loadStepContext: async (stepId) => {
+    const ctx = await api.getStepContext(stepId);
+    set((s) => ({ stepContexts: { ...s.stepContexts, [stepId]: ctx } }));
+  },
+
+  invalidateStepContext: (stepId) => {
+    set((s) => {
+      const { [stepId]: _, ...rest } = s.stepContexts;
+      return { stepContexts: rest };
+    });
   },
 
   setStepTags: async (stepId, tagNames) => {
     const tags = await api.setStepTags(stepId, tagNames);
-    set((s) => ({ stepTags: { ...s.stepTags, [stepId]: tags } }));
+    set((s) => {
+      const ctx = s.stepContexts[stepId];
+      if (!ctx) return {};
+      return { stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, tags } } };
+    });
+  },
+
+  setStepPaintRefs: async (stepId, entryIds) => {
+    const refs = await api.setStepPaintRefs(stepId, entryIds);
+    set((s) => {
+      const ctx = s.stepContexts[stepId];
+      if (!ctx) return {};
+      return { stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, paint_refs: refs } } };
+    });
   },
 
   refreshProjectPaletteEntries: async () => {
@@ -705,16 +698,6 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
     if (!projectId) return;
     const entries = await api.listPaletteEntries(projectId);
     set({ projectPaletteEntries: entries });
-  },
-
-  loadStepPaintRefs: async (stepId) => {
-    const refs = await api.listStepPaintRefs(stepId);
-    set((s) => ({ stepPaintRefs: { ...s.stepPaintRefs, [stepId]: refs } }));
-  },
-
-  setStepPaintRefs: async (stepId, entryIds) => {
-    const refs = await api.setStepPaintRefs(stepId, entryIds);
-    set((s) => ({ stepPaintRefs: { ...s.stepPaintRefs, [stepId]: refs } }));
   },
 
   // ── Sprue Refs ──────────────────────────────────────────────────────────
@@ -744,119 +727,103 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
 
   // ── Step Sprue Parts ──────────────────────────────────────────────────
 
-  loadStepSprueParts: async (stepId) => {
-    const parts = await api.listStepSprueParts(stepId);
-    set((s) => ({ stepSprueParts: { ...s.stepSprueParts, [stepId]: parts } }));
-  },
-
   loadProjectSprueParts: async (projectId) => {
     const parts = await api.listProjectSprueParts(projectId);
     set({ projectSprueParts: parts });
   },
 
   addStepSpruePartStore: (part) => {
-    set((s) => ({
-      stepSprueParts: {
-        ...s.stepSprueParts,
-        [part.step_id]: [...(s.stepSprueParts[part.step_id] ?? []), part],
-      },
-      projectSprueParts: [...s.projectSprueParts, part],
-    }));
-  },
-
-  removeStepSpruePartStore: (stepId, id) => {
-    set((s) => ({
-      stepSprueParts: {
-        ...s.stepSprueParts,
-        [stepId]: (s.stepSprueParts[stepId] ?? []).filter((p) => p.id !== id),
-      },
-      projectSprueParts: s.projectSprueParts.filter((p) => p.id !== id),
-    }));
-  },
-
-  setSpruePartTicked: (stepId, partId, tickedCount) => {
-    const prev = get().stepSprueParts[stepId]?.find((p) => p.id === partId)?.ticked_count ?? 0;
-    if (tickedCount === prev) return;
-    set((s) => ({
-      stepSprueParts: {
-        ...s.stepSprueParts,
-        [stepId]: (s.stepSprueParts[stepId] ?? []).map((p) =>
-          p.id === partId ? { ...p, ticked_count: tickedCount } : p,
-        ),
-      },
-      projectSprueParts: s.projectSprueParts.map((p) =>
-        p.id === partId ? { ...p, ticked_count: tickedCount } : p,
-      ),
-    }));
-    api.setSpruePartTicked(partId, tickedCount).catch(() => {
-      set((s) => ({
-        stepSprueParts: {
-          ...s.stepSprueParts,
-          [stepId]: (s.stepSprueParts[stepId] ?? []).map((p) =>
-            p.id === partId ? { ...p, ticked_count: prev } : p,
-          ),
-        },
-        projectSprueParts: s.projectSprueParts.map((p) =>
-          p.id === partId ? { ...p, ticked_count: prev } : p,
-        ),
-      }));
+    set((s) => {
+      const ctx = s.stepContexts[part.step_id];
+      return {
+        stepContexts: ctx ? {
+          ...s.stepContexts,
+          [part.step_id]: { ...ctx, sprue_parts: [...ctx.sprue_parts, part] },
+        } : s.stepContexts,
+        projectSprueParts: [...s.projectSprueParts, part],
+      };
     });
   },
 
-  loadStepRelations: async (stepId) => {
-    const relations = await api.listStepRelations(stepId);
-    set((s) => ({ stepRelations: { ...s.stepRelations, [stepId]: relations } }));
+  removeStepSpruePartStore: (stepId, id) => {
+    set((s) => {
+      const ctx = s.stepContexts[stepId];
+      return {
+        stepContexts: ctx ? {
+          ...s.stepContexts,
+          [stepId]: { ...ctx, sprue_parts: ctx.sprue_parts.filter((p) => p.id !== id) },
+        } : s.stepContexts,
+        projectSprueParts: s.projectSprueParts.filter((p) => p.id !== id),
+      };
+    });
+  },
+
+  setSpruePartTicked: (stepId, partId, tickedCount) => {
+    const ctx = get().stepContexts[stepId];
+    const prev = ctx?.sprue_parts.find((p) => p.id === partId)?.ticked_count ?? 0;
+    if (tickedCount === prev) return;
+    const mapPart = (p: StepSpruePart) =>
+      p.id === partId ? { ...p, ticked_count: tickedCount } : p;
+    const rollbackPart = (p: StepSpruePart) =>
+      p.id === partId ? { ...p, ticked_count: prev } : p;
+    set((s) => {
+      const c = s.stepContexts[stepId];
+      return {
+        stepContexts: c ? {
+          ...s.stepContexts,
+          [stepId]: { ...c, sprue_parts: c.sprue_parts.map(mapPart) },
+        } : s.stepContexts,
+        projectSprueParts: s.projectSprueParts.map(mapPart),
+      };
+    });
+    api.setSpruePartTicked(partId, tickedCount).catch(() => {
+      set((s) => {
+        const c = s.stepContexts[stepId];
+        return {
+          stepContexts: c ? {
+            ...s.stepContexts,
+            [stepId]: { ...c, sprue_parts: c.sprue_parts.map(rollbackPart) },
+          } : s.stepContexts,
+          projectSprueParts: s.projectSprueParts.map(rollbackPart),
+        };
+      });
+    });
   },
 
   setStepRelations: async (stepId, relations) => {
     const result = await api.setStepRelations(stepId, relations);
-    set((s) => ({ stepRelations: { ...s.stepRelations, [stepId]: result } }));
-  },
-
-  loadStepReferenceImages: async (stepId) => {
-    const images = await api.listReferenceImages(stepId);
-    set((s) => ({ stepReferenceImages: { ...s.stepReferenceImages, [stepId]: images } }));
+    set((s) => {
+      const ctx = s.stepContexts[stepId];
+      if (!ctx) return {};
+      return { stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, relations: result } } };
+    });
   },
 
   addReferenceImageStore: (img) => {
-    set((s) => ({
-      stepReferenceImages: {
-        ...s.stepReferenceImages,
-        [img.step_id]: [...(s.stepReferenceImages[img.step_id] ?? []), img],
-      },
-    }));
+    set((s) => {
+      const ctx = s.stepContexts[img.step_id];
+      if (!ctx) return {};
+      return { stepContexts: { ...s.stepContexts, [img.step_id]: { ...ctx, reference_images: [...ctx.reference_images, img] } } };
+    });
   },
 
   updateReferenceImageStore: (img) => {
-    set((s) => ({
-      stepReferenceImages: {
-        ...s.stepReferenceImages,
-        [img.step_id]: (s.stepReferenceImages[img.step_id] ?? []).map((i) =>
-          i.id === img.id ? img : i,
-        ),
-      },
-    }));
+    set((s) => {
+      const ctx = s.stepContexts[img.step_id];
+      if (!ctx) return {};
+      return { stepContexts: { ...s.stepContexts, [img.step_id]: { ...ctx, reference_images: ctx.reference_images.map((i) => i.id === img.id ? img : i) } } };
+    });
   },
 
   removeReferenceImageStore: (stepId, id) => {
-    set((s) => ({
-      stepReferenceImages: {
-        ...s.stepReferenceImages,
-        [stepId]: (s.stepReferenceImages[stepId] ?? []).filter((i) => i.id !== id),
-      },
-    }));
+    set((s) => {
+      const ctx = s.stepContexts[stepId];
+      if (!ctx) return {};
+      return { stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, reference_images: ctx.reference_images.filter((i) => i.id !== id) } } };
+    });
   },
 
   // ── Annotations ─────────────────────────────────────────────────────────
-
-  loadAnnotations: async (stepId) => {
-    try {
-      const annotations = await api.getAnnotations(stepId);
-      set((s) => ({ stepAnnotations: { ...s.stepAnnotations, [stepId]: annotations ?? [] } }));
-    } catch {
-      set((s) => ({ stepAnnotations: { ...s.stepAnnotations, [stepId]: [] } }));
-    }
-  },
 
   saveAnnotationsDebounced: (() => {
     const timers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -865,7 +832,7 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
       if (existing) clearTimeout(existing);
       timers.set(stepId, setTimeout(() => {
         timers.delete(stepId);
-        const annotations = get().stepAnnotations[stepId];
+        const annotations = get().stepContexts[stepId]?.annotations;
         if (annotations) {
           api.saveAnnotations(stepId, annotations).catch(() => {});
         }
@@ -874,41 +841,51 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
   })(),
 
   addAnnotation: (stepId, annotation) => {
-    const current = get().stepAnnotations[stepId] ?? [];
+    const ctx = get().stepContexts[stepId];
+    if (!ctx) return;
+    const current = ctx.annotations;
     set((s) => ({
-      stepAnnotations: { ...s.stepAnnotations, [stepId]: [...current, annotation] },
+      stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: [...current, annotation] } },
       ...annotationUndoSnapshot(s, stepId, current),
     }));
     get().saveAnnotationsDebounced(stepId);
   },
 
   removeAnnotation: (stepId, annotationId) => {
-    const current = get().stepAnnotations[stepId] ?? [];
+    const ctx = get().stepContexts[stepId];
+    if (!ctx) return;
+    const current = ctx.annotations;
     set((s) => ({
-      stepAnnotations: { ...s.stepAnnotations, [stepId]: current.filter((a) => a.id !== annotationId) },
+      stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: current.filter((a) => a.id !== annotationId) } },
       ...annotationUndoSnapshot(s, stepId, current),
     }));
     get().saveAnnotationsDebounced(stepId);
   },
 
   clearAnnotations: (stepId) => {
-    const current = get().stepAnnotations[stepId] ?? [];
-    if (current.length === 0) return;
+    const ctx = get().stepContexts[stepId];
+    if (!ctx || ctx.annotations.length === 0) return;
+    const current = ctx.annotations;
     set((s) => ({
-      stepAnnotations: { ...s.stepAnnotations, [stepId]: [] },
+      stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: [] } },
       ...annotationUndoSnapshot(s, stepId, current),
     }));
     get().saveAnnotationsDebounced(stepId);
   },
 
   updateAnnotation: (stepId, annotationId, updates) => {
-    const current = get().stepAnnotations[stepId] ?? [];
+    const ctx = get().stepContexts[stepId];
+    if (!ctx) return;
+    const current = ctx.annotations;
     set((s) => ({
-      stepAnnotations: {
-        ...s.stepAnnotations,
-        [stepId]: current.map((a) =>
-          a.id === annotationId ? { ...a, ...updates } as Annotation : a,
-        ),
+      stepContexts: {
+        ...s.stepContexts,
+        [stepId]: {
+          ...ctx,
+          annotations: current.map((a) =>
+            a.id === annotationId ? { ...a, ...updates } as Annotation : a,
+          ),
+        },
       },
       ...annotationUndoSnapshot(s, stepId, current),
     }));
@@ -928,10 +905,12 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
   undoAnnotation: (stepId) => {
     const undoStack = get().annotationUndoStacks[stepId] ?? [];
     if (undoStack.length === 0) return;
-    const current = get().stepAnnotations[stepId] ?? [];
+    const ctx = get().stepContexts[stepId];
+    if (!ctx) return;
+    const current = ctx.annotations;
     const previous = undoStack[undoStack.length - 1];
     set((s) => ({
-      stepAnnotations: { ...s.stepAnnotations, [stepId]: previous },
+      stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: previous } },
       annotationUndoStacks: {
         ...s.annotationUndoStacks,
         [stepId]: undoStack.slice(0, -1),
@@ -947,10 +926,12 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
   redoAnnotation: (stepId) => {
     const redoStack = get().annotationRedoStacks[stepId] ?? [];
     if (redoStack.length === 0) return;
-    const current = get().stepAnnotations[stepId] ?? [];
+    const ctx = get().stepContexts[stepId];
+    if (!ctx) return;
+    const current = ctx.annotations;
     const next = redoStack[redoStack.length - 1];
     set((s) => ({
-      stepAnnotations: { ...s.stepAnnotations, [stepId]: next },
+      stepContexts: { ...s.stepContexts, [stepId]: { ...ctx, annotations: next } },
       annotationRedoStacks: {
         ...s.annotationRedoStacks,
         [stepId]: redoStack.slice(0, -1),
@@ -1169,13 +1150,13 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
     const step = state.steps.find((s) => s.id === stepId);
     if (!step || step.is_completed) return;
 
-    // Ensure relations are loaded
-    if (!state.stepRelations[stepId]) {
-      await get().loadStepRelations(stepId);
+    // Ensure context is loaded (includes relations)
+    if (!state.stepContexts[stepId]) {
+      await get().loadStepContext(stepId);
     }
 
     const freshState = get();
-    const relations = freshState.stepRelations[stepId] ?? [];
+    const relations = freshState.stepContexts[stepId]?.relations ?? [];
     const warnings = getCompletionWarnings(stepId, freshState.steps, relations);
 
     if (!hasCompletionWarnings(warnings)) {
@@ -1229,14 +1210,11 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
 
     set(updates);
 
-    // Load annotations for active step when entering building mode
+    // Load step context for active step when entering building mode
     if (mode === "building") {
       const activeId = (updates as Record<string, unknown>).activeStepId as string ?? state.activeStepId;
-      if (activeId) {
-        const step = state.steps.find((s) => s.id === activeId);
-        if (step?.crop_x != null && !state.stepAnnotations[activeId]) {
-          get().loadAnnotations(activeId);
-        }
+      if (activeId && !state.stepContexts[activeId]) {
+        get().loadStepContext(activeId);
       }
     }
     try {
@@ -1448,13 +1426,14 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
     try {
       await api.redetectStepSprues(stepId);
       set((s) => {
-        const stepParts = s.stepSprueParts[stepId] ?? [];
+        const ctx = s.stepContexts[stepId];
+        const stepParts = ctx?.sprue_parts ?? [];
         const aiPartIds = new Set(stepParts.filter((p) => p.ai_detected).map((p) => p.id));
         return {
-          stepSprueParts: {
-            ...s.stepSprueParts,
-            [stepId]: stepParts.filter((p) => !p.ai_detected),
-          },
+          stepContexts: ctx ? {
+            ...s.stepContexts,
+            [stepId]: { ...ctx, sprue_parts: stepParts.filter((p) => !p.ai_detected) },
+          } : s.stepContexts,
           projectSprueParts: s.projectSprueParts.filter((p) => !aiPartIds.has(p.id)),
           steps: s.steps.map((st) => st.id === stepId ? { ...st, sprues_detected: false } : st),
         };

--- a/src/store/settings-slice.ts
+++ b/src/store/settings-slice.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from "zustand";
 import type { AppStore } from "./index";
 import { SETTINGS_DEFAULTS } from "@/shared/types";
 import * as api from "@/api";
+import { toast } from "sonner";
 
 export interface SettingsSlice {
   settings: Record<string, string>;
@@ -34,6 +35,6 @@ export const createSettingsSlice: StateCreator<AppStore, [], [], SettingsSlice> 
     set((s) => ({
       settings: { ...s.settings, [key]: value },
     }));
-    api.setSetting(key, value).catch(() => {});
+    api.setSetting(key, value).catch((e) => toast.error(`Failed to save setting: ${e}`));
   },
 });

--- a/src/store/timer-slice.ts
+++ b/src/store/timer-slice.ts
@@ -3,6 +3,7 @@ import type { DryingTimer } from "@/shared/types";
 import { getSettingBool } from "@/shared/types";
 import type { AppStore } from "./index";
 import * as api from "@/api";
+import { toast } from "sonner";
 import {
   isPermissionGranted,
   requestPermission,
@@ -49,7 +50,7 @@ function handleTimerExpired(
         entryType: "note",
         body: `Drying timer completed: ${t.label} (${t.duration_min} min)`,
       })
-      .catch(() => {});
+      .catch((e) => toast.error(`Failed to log timer expiry: ${e}`));
   }
   api.deleteDryingTimer(t.id).catch((e) => console.warn("Failed to delete expired timer:", e));
 }


### PR DESCRIPTION
## Summary
Closes #16

- **Bundled backend call**: New `get_step_context` Rust command fetches tags, relations, paint_refs, sprue_parts, reference_images, and annotations in a single IPC roundtrip (6→1 calls per step)
- **Single cache**: Replaced 7 separate per-step caches with one `stepContexts: Record<string, StepContext>` + `loadStepContext` / `invalidateStepContext`
- **Dropped dual sprue-parts sync**: Step-level mutations now reload the project cache from the server instead of manual dual-sync
- **Error surfacing**: All `.catch(() => {})` patterns replaced with `toast.error` across build-slice, settings-slice, and timer-slice
- **Consistent null-checks**: Normalized ternary patterns to early-return style

## Test plan
- [ ] Navigate between steps in build mode — verify all context data loads
- [ ] Tick/untick sprue parts — verify optimistic update + error rollback with toast
- [ ] Complete a step with blockers — verify completion warning dialog
- [ ] Add/edit/undo annotations — verify persistence
- [ ] Drying timer + settings error paths — verify toasts