### PR TITLE
Replace 5 mode fields with BuildView discriminated union

### DIFF
--- a/src-tauri/migrations/V18__build_view.sql
+++ b/src-tauri/migrations/V18__build_view.sql
@@ -1,0 +1,8 @@
+ALTER TABLE project_ui_state ADD COLUMN build_view TEXT;
+
+UPDATE project_ui_state
+SET build_view = CASE
+  WHEN build_mode = 'building' AND nav_mode = 'page' THEN '{"kind":"building-page"}'
+  WHEN build_mode = 'building' THEN '{"kind":"building-track","annotationMode":null}'
+  ELSE '{"kind":"setup-tracks","canvasMode":"view"}'
+END;

--- a/src-tauri/src/commands/instructions.rs
+++ b/src-tauri/src/commands/instructions.rs
@@ -141,16 +141,6 @@ pub fn delete_instruction_source(
 }
 
 #[tauri::command]
-pub fn save_build_mode(
-    db: State<'_, AppDb>,
-    project_id: String,
-    build_mode: String,
-) -> Result<(), String> {
-    let conn = db.conn()?;
-    crate::db::queries::project_ui_state::save_build_mode(&conn, &project_id, &build_mode)
-}
-
-#[tauri::command]
 pub fn save_active_track(
     db: State<'_, AppDb>,
     project_id: String,
@@ -162,16 +152,6 @@ pub fn save_active_track(
         &project_id,
         active_track_id.as_deref(),
     )
-}
-
-#[tauri::command]
-pub fn save_nav_mode(
-    db: State<'_, AppDb>,
-    project_id: String,
-    nav_mode: String,
-) -> Result<(), String> {
-    let conn = db.conn()?;
-    crate::db::queries::project_ui_state::save_nav_mode(&conn, &project_id, &nav_mode)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/instructions.rs
+++ b/src-tauri/src/commands/instructions.rs
@@ -175,6 +175,16 @@ pub fn save_nav_mode(
 }
 
 #[tauri::command]
+pub fn save_build_view(
+    db: State<'_, AppDb>,
+    project_id: String,
+    build_view: String,
+) -> Result<(), String> {
+    let conn = db.conn()?;
+    crate::db::queries::project_ui_state::save_build_view(&conn, &project_id, &build_view)
+}
+
+#[tauri::command]
 pub fn save_sprue_panel_open(
     db: State<'_, AppDb>,
     project_id: String,

--- a/src-tauri/src/db/queries/project_ui_state.rs
+++ b/src-tauri/src/db/queries/project_ui_state.rs
@@ -36,21 +36,6 @@ pub fn get_or_create(conn: &Connection, project_id: &str) -> Result<ProjectUiSta
     .map_err(|e| e.to_string())
 }
 
-pub fn save_build_mode(
-    conn: &Connection,
-    project_id: &str,
-    build_mode: &str,
-) -> Result<(), String> {
-    let ts = now();
-    conn.execute(
-        "UPDATE project_ui_state SET build_mode = ?1, updated_at = ?2
-         WHERE project_id = ?3",
-        params![build_mode, ts, project_id],
-    )
-    .map_err(|e| e.to_string())?;
-    Ok(())
-}
-
 pub fn save_active_track(
     conn: &Connection,
     project_id: &str,
@@ -61,21 +46,6 @@ pub fn save_active_track(
         "UPDATE project_ui_state SET active_track_id = ?1, updated_at = ?2
          WHERE project_id = ?3",
         params![active_track_id, ts, project_id],
-    )
-    .map_err(|e| e.to_string())?;
-    Ok(())
-}
-
-pub fn save_nav_mode(
-    conn: &Connection,
-    project_id: &str,
-    nav_mode: &str,
-) -> Result<(), String> {
-    let ts = now();
-    conn.execute(
-        "UPDATE project_ui_state SET nav_mode = ?1, updated_at = ?2
-         WHERE project_id = ?3",
-        params![nav_mode, ts, project_id],
     )
     .map_err(|e| e.to_string())?;
     Ok(())

--- a/src-tauri/src/db/queries/project_ui_state.rs
+++ b/src-tauri/src/db/queries/project_ui_state.rs
@@ -14,7 +14,7 @@ pub fn get_or_create(conn: &Connection, project_id: &str) -> Result<ProjectUiSta
 
     conn.query_row(
         "SELECT project_id, active_step_id, active_track_id, build_mode, nav_mode,
-                image_zoom, image_pan_x, image_pan_y, sprue_panel_open, updated_at
+                build_view, image_zoom, image_pan_x, image_pan_y, sprue_panel_open, updated_at
          FROM project_ui_state WHERE project_id = ?1",
         params![project_id],
         |row| {
@@ -24,11 +24,12 @@ pub fn get_or_create(conn: &Connection, project_id: &str) -> Result<ProjectUiSta
                 active_track_id: row.get(2)?,
                 build_mode: row.get(3)?,
                 nav_mode: row.get(4)?,
-                image_zoom: row.get(5)?,
-                image_pan_x: row.get(6)?,
-                image_pan_y: row.get(7)?,
-                sprue_panel_open: row.get(8)?,
-                updated_at: row.get(9)?,
+                build_view: row.get(5)?,
+                image_zoom: row.get(6)?,
+                image_pan_x: row.get(7)?,
+                image_pan_y: row.get(8)?,
+                sprue_panel_open: row.get(9)?,
+                updated_at: row.get(10)?,
             })
         },
     )
@@ -90,6 +91,21 @@ pub fn save_sprue_panel_open(
         "UPDATE project_ui_state SET sprue_panel_open = ?1, updated_at = ?2
          WHERE project_id = ?3",
         params![open, ts, project_id],
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+pub fn save_build_view(
+    conn: &Connection,
+    project_id: &str,
+    build_view: &str,
+) -> Result<(), String> {
+    let ts = now();
+    conn.execute(
+        "UPDATE project_ui_state SET build_view = ?1, updated_at = ?2
+         WHERE project_id = ?3",
+        params![build_view, ts, project_id],
     )
     .map_err(|e| e.to_string())?;
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -104,8 +104,6 @@ pub fn run() {
             commands::instructions::set_page_rotation,
             commands::instructions::get_project_ui_state,
             commands::instructions::save_view_state,
-            commands::instructions::save_build_mode,
-            commands::instructions::save_nav_mode,
             commands::instructions::save_build_view,
             commands::instructions::save_active_track,
             commands::instructions::save_sprue_panel_open,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,6 +106,7 @@ pub fn run() {
             commands::instructions::save_view_state,
             commands::instructions::save_build_mode,
             commands::instructions::save_nav_mode,
+            commands::instructions::save_build_view,
             commands::instructions::save_active_track,
             commands::instructions::save_sprue_panel_open,
             commands::tracks::list_tracks,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -669,6 +669,7 @@ pub struct ProjectUiState {
     pub active_track_id: Option<String>,
     pub build_mode: String,
     pub nav_mode: String,
+    pub build_view: Option<String>,
     pub image_zoom: f64,
     pub image_pan_x: f64,
     pub image_pan_y: f64,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -619,13 +619,6 @@ export async function getProjectUiState(
   return invoke<ProjectUiState>("get_project_ui_state", { projectId });
 }
 
-export async function saveBuildMode(
-  projectId: string,
-  buildMode: string,
-): Promise<void> {
-  return invoke<void>("save_build_mode", { projectId, buildMode });
-}
-
 export async function saveActiveTrack(
   projectId: string,
   activeTrackId: string | null,
@@ -638,13 +631,6 @@ export async function saveSpruePanel(
   open: boolean,
 ): Promise<void> {
   return invoke<void>("save_sprue_panel_open", { projectId, open });
-}
-
-export async function saveNavMode(
-  projectId: string,
-  navMode: string,
-): Promise<void> {
-  return invoke<void>("save_nav_mode", { projectId, navMode });
 }
 
 export async function saveBuildView(

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -51,6 +51,7 @@ import type {
   SprueDepletionSummary,
   DetectionResponse,
   StepContext,
+  BuildView,
 } from "@/shared/types";
 
 // ── Kits ────────────────────────────────────────────────────────────────────
@@ -644,6 +645,13 @@ export async function saveNavMode(
   navMode: string,
 ): Promise<void> {
   return invoke<void>("save_nav_mode", { projectId, navMode });
+}
+
+export async function saveBuildView(
+  projectId: string,
+  buildView: BuildView,
+): Promise<void> {
+  return invoke<void>("save_build_view", { projectId, buildView: JSON.stringify(buildView) });
 }
 
 export async function saveViewState(

--- a/src/components/build/AnnotationLayer.tsx
+++ b/src/components/build/AnnotationLayer.tsx
@@ -36,7 +36,7 @@ function toLayerY(ny: number, h: number) { return ny * h; }
 
 export function AnnotationLayer({ stepId, effectiveW, effectiveH, zoom, drawPreview, previewColor }: AnnotationLayerProps) {
   const annotations = useAppStore((s) => s.stepContexts[stepId]?.annotations ?? EMPTY_ANNOTATIONS);
-  const annotationMode = useAppStore((s) => s.annotationMode);
+  const annotationMode = useAppStore((s) => s.buildView.kind === "building-track" ? s.buildView.annotationMode : null);
   const removeAnnotation = useAppStore((s) => s.removeAnnotation);
   const { accent: SELECTION_COLOR } = useTheme();
   const updateAnnotation = useAppStore((s) => s.updateAnnotation);

--- a/src/components/build/AnnotationLayer.tsx
+++ b/src/components/build/AnnotationLayer.tsx
@@ -3,6 +3,7 @@ import { Layer, Line, Ellipse, Arrow, Rect, Text, Group } from "react-konva";
 import { useAppStore } from "@/store";
 import { useTheme } from "@/hooks/useTheme";
 import type { Annotation } from "@/shared/types";
+import { getAnnotationMode } from "@/shared/types";
 
 const EMPTY_ANNOTATIONS: Annotation[] = [];
 
@@ -36,7 +37,7 @@ function toLayerY(ny: number, h: number) { return ny * h; }
 
 export function AnnotationLayer({ stepId, effectiveW, effectiveH, zoom, drawPreview, previewColor }: AnnotationLayerProps) {
   const annotations = useAppStore((s) => s.stepContexts[stepId]?.annotations ?? EMPTY_ANNOTATIONS);
-  const annotationMode = useAppStore((s) => s.buildView.kind === "building-track" ? s.buildView.annotationMode : null);
+  const annotationMode = useAppStore((s) => getAnnotationMode(s.buildView));
   const removeAnnotation = useAppStore((s) => s.removeAnnotation);
   const { accent: SELECTION_COLOR } = useTheme();
   const updateAnnotation = useAppStore((s) => s.updateAnnotation);

--- a/src/components/build/AnnotationToolbar.tsx
+++ b/src/components/build/AnnotationToolbar.tsx
@@ -36,7 +36,7 @@ const STROKE_PRESETS: { label: string; value: number; thickness: number }[] = [
 
 export function AnnotationToolbar() {
   const { accent } = useTheme();
-  const annotationMode = useAppStore((s) => s.annotationMode);
+  const annotationMode = useAppStore((s) => s.buildView.kind === "building-track" ? s.buildView.annotationMode : null);
   const setAnnotationMode = useAppStore((s) => s.setAnnotationMode);
   const annotationColor = useAppStore((s) => s.annotationColor);
   const setAnnotationColor = useAppStore((s) => s.setAnnotationColor);

--- a/src/components/build/AnnotationToolbar.tsx
+++ b/src/components/build/AnnotationToolbar.tsx
@@ -4,7 +4,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip
 import { useAppStore } from "@/store";
 import { useTheme } from "@/hooks/useTheme";
 import type { Annotation, AnnotationTool } from "@/shared/types";
-import { ANNOTATION_TOOL_LABELS } from "@/shared/types";
+import { ANNOTATION_TOOL_LABELS, getAnnotationMode } from "@/shared/types";
 
 const EMPTY_ANNOTATIONS: Annotation[] = [];
 const EMPTY_STACK: Annotation[][] = [];
@@ -36,7 +36,7 @@ const STROKE_PRESETS: { label: string; value: number; thickness: number }[] = [
 
 export function AnnotationToolbar() {
   const { accent } = useTheme();
-  const annotationMode = useAppStore((s) => s.buildView.kind === "building-track" ? s.buildView.annotationMode : null);
+  const annotationMode = useAppStore((s) => getAnnotationMode(s.buildView));
   const setAnnotationMode = useAppStore((s) => s.setAnnotationMode);
   const annotationColor = useAppStore((s) => s.annotationColor);
   const setAnnotationColor = useAppStore((s) => s.setAnnotationColor);

--- a/src/components/build/BuildToolbar.tsx
+++ b/src/components/build/BuildToolbar.tsx
@@ -5,7 +5,7 @@ import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { SegmentedPill } from "@/components/shared/SegmentedPill";
 import { useAppStore } from "@/store";
-import type { BuildMode, NavMode, SetupRailMode } from "@/store/build-slice";
+
 import * as api from "@/api";
 import { useUploadPdf } from "./useUploadPdf";
 import { zoomIn, zoomOut } from "./zoom-utils";
@@ -17,22 +17,17 @@ interface BuildToolbarProps {
 
 export function BuildToolbar({ onOpenSourceManager, onOpenShortcuts }: BuildToolbarProps) {
   const project = useAppStore((s) => s.project);
-  const buildMode = useAppStore((s) => s.buildMode);
-  const setBuildMode = useAppStore((s) => s.setBuildMode);
+  const buildView = useAppStore((s) => s.buildView);
+  const setBuildView = useAppStore((s) => s.setBuildView);
   const tracks = useAppStore((s) => s.tracks);
   const activeTrackId = useAppStore((s) => s.activeTrackId);
   const instructionSources = useAppStore((s) => s.instructionSources);
   const viewerZoom = useAppStore((s) => s.viewerZoom);
   const requestFitToView = useAppStore((s) => s.requestFitToView);
   const rotatePage = useAppStore((s) => s.rotatePage);
-  const canvasMode = useAppStore((s) => s.canvasMode);
   const setCanvasMode = useAppStore((s) => s.setCanvasMode);
   const activeStepId = useAppStore((s) => s.activeStepId);
   const clearClipPolygon = useAppStore((s) => s.clearClipPolygon);
-  const navMode = useAppStore((s) => s.navMode);
-  const setNavMode = useAppStore((s) => s.setNavMode);
-  const setupRailMode = useAppStore((s) => s.setupRailMode);
-  const setSetupRailMode = useAppStore((s) => s.setSetupRailMode);
   const sprueRefs = useAppStore((s) => s.sprueRefs);
   const currentSourcePages = useAppStore((s) => s.currentSourcePages);
   const currentPageIndex = useAppStore((s) => s.currentPageIndex);
@@ -43,6 +38,11 @@ export function BuildToolbar({ onOpenSourceManager, onOpenShortcuts }: BuildTool
   const loadTracks = useAppStore((s) => s.loadTracks);
   const pushUndo = useAppStore((s) => s.pushUndo);
   const triggerAutoDetect = useAppStore((s) => s.triggerAutoDetect);
+
+  const isSetup = buildView.kind === "setup-tracks" || buildView.kind === "setup-sprues";
+  const canvasMode = "canvasMode" in buildView ? buildView.canvasMode : "view";
+  const setupRailMode = buildView.kind === "setup-sprues" ? "sprues" : "steps";
+  const navMode = buildView.kind === "building-page" ? "page" : "track";
 
   const activeTrack = activeTrackId
     ? tracks.find((t) => t.id === activeTrackId) ?? null
@@ -103,39 +103,48 @@ export function BuildToolbar({ onOpenSourceManager, onOpenShortcuts }: BuildTool
       <SegmentedPill
         size="sm"
         items={[
-          { value: "setup" as BuildMode, label: "Setup", icon: <Settings2 className="h-3 w-3" /> },
-          { value: "building" as BuildMode, label: "Building", icon: <Hammer className="h-3 w-3" /> },
+          { value: "setup" as const, label: "Setup", icon: <Settings2 className="h-3 w-3" /> },
+          { value: "building" as const, label: "Building", icon: <Hammer className="h-3 w-3" /> },
         ]}
-        value={buildMode}
-        onChange={setBuildMode}
+        value={isSetup ? "setup" : "building"}
+        onChange={(v) => {
+          if (v === "setup") setBuildView({ kind: "setup-tracks", canvasMode: "view" });
+          else setBuildView({ kind: "building-track", annotationMode: null });
+        }}
       />
 
-      {buildMode === "setup" && (
+      {isSetup && (
         <>
           <Separator orientation="vertical" className="h-[14px]" />
           <SegmentedPill
             size="sm"
             items={[
-              { value: "steps" as SetupRailMode, label: "Steps", icon: <List className="h-3 w-3" /> },
-              { value: "sprues" as SetupRailMode, label: "Sprues", icon: <Box className="h-3 w-3" />, count: sprueRefs.length || undefined },
+              { value: "steps" as const, label: "Steps", icon: <List className="h-3 w-3" /> },
+              { value: "sprues" as const, label: "Sprues", icon: <Box className="h-3 w-3" />, count: sprueRefs.length || undefined },
             ]}
             value={setupRailMode}
-            onChange={setSetupRailMode}
+            onChange={(v) => {
+              if (v === "sprues") setBuildView({ kind: "setup-sprues", canvasMode: "view" });
+              else setBuildView({ kind: "setup-tracks", canvasMode: "view" });
+            }}
           />
         </>
       )}
 
-      {buildMode === "building" && instructionSources.length > 0 && (
+      {!isSetup && instructionSources.length > 0 && (
         <>
           <Separator orientation="vertical" className="h-[14px]" />
           <SegmentedPill
             size="sm"
             items={[
-              { value: "track" as NavMode, label: "Steps", icon: <List className="h-3 w-3" /> },
-              { value: "page" as NavMode, label: "Pages", icon: <FileText className="h-3 w-3" /> },
+              { value: "track" as const, label: "Steps", icon: <List className="h-3 w-3" /> },
+              { value: "page" as const, label: "Pages", icon: <FileText className="h-3 w-3" /> },
             ]}
             value={navMode}
-            onChange={setNavMode}
+            onChange={(v) => {
+              if (v === "page") setBuildView({ kind: "building-page" });
+              else setBuildView({ kind: "building-track", annotationMode: null });
+            }}
           />
         </>
       )}
@@ -167,7 +176,7 @@ export function BuildToolbar({ onOpenSourceManager, onOpenShortcuts }: BuildTool
       {instructionSources.length > 0 && (
         <>
           {/* View/Crop toggle — setup only */}
-          {buildMode === "setup" && (
+          {isSetup && (
             <>
               <div className="flex items-center rounded-md border border-border">
                 <Tooltip>
@@ -336,7 +345,7 @@ export function BuildToolbar({ onOpenSourceManager, onOpenShortcuts }: BuildTool
       )}
 
       {/* Upload button — setup only */}
-      {buildMode === "setup" && (
+      {isSetup && (
         <Button
           size="sm"
           onClick={handleUploadPdf}

--- a/src/components/build/BuildToolbar.tsx
+++ b/src/components/build/BuildToolbar.tsx
@@ -1,12 +1,10 @@
 import { Upload, ZoomIn, ZoomOut, Maximize2, FileStack, RotateCw, MousePointer, Crop, Pentagon, RectangleHorizontal, Keyboard, Settings2, Hammer, List, FileText, Eraser, Box } from "lucide-react";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { SegmentedPill } from "@/components/shared/SegmentedPill";
 import { useAppStore } from "@/store";
-
-import * as api from "@/api";
+import { getCanvasMode } from "@/shared/types";
 import { useUploadPdf } from "./useUploadPdf";
 import { zoomIn, zoomOut } from "./zoom-utils";
 
@@ -29,18 +27,11 @@ export function BuildToolbar({ onOpenSourceManager, onOpenShortcuts }: BuildTool
   const activeStepId = useAppStore((s) => s.activeStepId);
   const clearClipPolygon = useAppStore((s) => s.clearClipPolygon);
   const sprueRefs = useAppStore((s) => s.sprueRefs);
-  const currentSourcePages = useAppStore((s) => s.currentSourcePages);
-  const currentPageIndex = useAppStore((s) => s.currentPageIndex);
   const steps = useAppStore((s) => s.steps);
-  const addStep = useAppStore((s) => s.addStep);
-  const setActiveStep = useAppStore((s) => s.setActiveStep);
-  const activeProjectId = useAppStore((s) => s.activeProjectId);
-  const loadTracks = useAppStore((s) => s.loadTracks);
-  const pushUndo = useAppStore((s) => s.pushUndo);
-  const triggerAutoDetect = useAppStore((s) => s.triggerAutoDetect);
+  const createFullPageStep = useAppStore((s) => s.createFullPageStep);
 
   const isSetup = buildView.kind === "setup-tracks" || buildView.kind === "setup-sprues";
-  const canvasMode = "canvasMode" in buildView ? buildView.canvasMode : "view";
+  const canvasMode = getCanvasMode(buildView);
   const setupRailMode = buildView.kind === "setup-sprues" ? "sprues" : "steps";
   const navMode = buildView.kind === "building-page" ? "page" : "track";
 
@@ -56,46 +47,10 @@ export function BuildToolbar({ onOpenSourceManager, onOpenShortcuts }: BuildTool
 
   const zoomPercent = Math.round(viewerZoom * 100);
 
-  const currentPage = currentSourcePages[currentPageIndex];
-
   // Polygon mode requires a track (same as crop mode)
   const activeStep = activeStepId ? steps.find((s) => s.id === activeStepId) : null;
   const canPolygon = activeTrackId != null;
   const hasPolygon = activeStep != null && activeStep.clip_polygon != null;
-
-  const handleFullPage = async () => {
-    if (!activeTrackId) {
-      toast.info("Select a track first");
-      return;
-    }
-    if (!currentPage) {
-      toast.info("No page selected");
-      return;
-    }
-    const trackSteps = steps.filter((s) => s.track_id === activeTrackId);
-    const rootCount = trackSteps.filter((s) => !s.parent_step_id).length;
-    const title = `Step ${rootCount + 1}`;
-    try {
-      const step = await api.createStep({
-        track_id: activeTrackId,
-        title,
-        source_page_id: currentPage.id,
-        is_full_page: true,
-        crop_x: 0,
-        crop_y: 0,
-        crop_w: currentPage.width,
-        crop_h: currentPage.height,
-      });
-      addStep(step);
-      pushUndo(step.id);
-      setActiveStep(step.id);
-      triggerAutoDetect(step.id);
-      if (activeProjectId) loadTracks(activeProjectId);
-      toast.success("Step created", { toasterId: "canvas" });
-    } catch (e) {
-      toast.error(`Failed to create step: ${e}`, { toasterId: "canvas" });
-    }
-  };
 
   return (
     <div className="flex items-center gap-2 border-b border-border bg-background px-3 py-1">
@@ -248,7 +203,7 @@ export function BuildToolbar({ onOpenSourceManager, onOpenShortcuts }: BuildTool
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
-                    onClick={handleFullPage}
+                    onClick={createFullPageStep}
                     className="rounded p-1 text-text-tertiary hover:bg-muted hover:text-text-secondary"
                   >
                     <RectangleHorizontal className="h-3.5 w-3.5" />

--- a/src/components/build/CropCanvas.tsx
+++ b/src/components/build/CropCanvas.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store";
 import type { Step, InstructionPage } from "@/shared/types";
+import { getAnnotationMode } from "@/shared/types";
 import { getEffectiveDimensions } from "./tree-utils";
 import { imagePointToEffective } from "./CropLayer";
 import { AnnotationLayer, DEFAULT_CHECKMARK_SIZE, DEFAULT_CROSS_SIZE, DEFAULT_OPACITY, HIGHLIGHT_COLOR } from "./AnnotationLayer";
@@ -77,7 +78,7 @@ export function CropCanvas() {
   const setViewerZoom = useAppStore((s) => s.setViewerZoom);
   const setViewerPan = useAppStore((s) => s.setViewerPan);
   const fitToViewTrigger = useAppStore((s) => s.fitToViewTrigger);
-  const annotationMode = useAppStore((s) => s.buildView.kind === "building-track" ? s.buildView.annotationMode : null);
+  const annotationMode = useAppStore((s) => getAnnotationMode(s.buildView));
   const annotationColor = useAppStore((s) => s.annotationColor);
   const addAnnotation = useAppStore((s) => s.addAnnotation);
   const annotationStrokeWidth = useAppStore((s) => s.annotationStrokeWidth);

--- a/src/components/build/CropCanvas.tsx
+++ b/src/components/build/CropCanvas.tsx
@@ -77,7 +77,7 @@ export function CropCanvas() {
   const setViewerZoom = useAppStore((s) => s.setViewerZoom);
   const setViewerPan = useAppStore((s) => s.setViewerPan);
   const fitToViewTrigger = useAppStore((s) => s.fitToViewTrigger);
-  const annotationMode = useAppStore((s) => s.annotationMode);
+  const annotationMode = useAppStore((s) => s.buildView.kind === "building-track" ? s.buildView.annotationMode : null);
   const annotationColor = useAppStore((s) => s.annotationColor);
   const addAnnotation = useAppStore((s) => s.addAnnotation);
   const annotationStrokeWidth = useAppStore((s) => s.annotationStrokeWidth);

--- a/src/components/build/InstructionCanvas.tsx
+++ b/src/components/build/InstructionCanvas.tsx
@@ -66,7 +66,7 @@ export function InstructionCanvas() {
   const setViewerPan = useAppStore((s) => s.setViewerPan);
   const fitToViewTrigger = useAppStore((s) => s.fitToViewTrigger);
   const focusCropTrigger = useAppStore((s) => s.focusCropTrigger);
-  const canvasMode = useAppStore((s) => s.canvasMode);
+  const canvasMode = useAppStore((s) => "canvasMode" in s.buildView ? s.buildView.canvasMode : "view");
 
   const currentPage = currentSourcePages[currentPageIndex];
   const imageSrc = currentPage ? convertFileSrc(currentPage.file_path) : null;
@@ -88,7 +88,7 @@ export function InstructionCanvas() {
   // Crop drawing (steps)
   const { drawingRect, onMouseDown, onMouseMove, onMouseUp } = useCropDrawing(stageRef);
   // Crop drawing (sprues)
-  const setupRailMode = useAppStore((s) => s.setupRailMode);
+  const setupRailMode = useAppStore((s) => s.buildView.kind === "setup-sprues" ? "sprues" : "steps");
   const sprueDrawing = useSprueDrawing(stageRef);
   const isSprueMode = setupRailMode === "sprues";
 

--- a/src/components/build/InstructionCanvas.tsx
+++ b/src/components/build/InstructionCanvas.tsx
@@ -3,6 +3,7 @@ import { Stage, Layer, Rect, Image as KonvaImage } from "react-konva";
 import useImage from "use-image";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store";
+import { getCanvasMode } from "@/shared/types";
 import * as api from "@/api";
 import { useCropDrawing } from "@/hooks/useCropDrawing";
 import { useSprueDrawing } from "@/hooks/useSprueDrawing";
@@ -66,7 +67,7 @@ export function InstructionCanvas() {
   const setViewerPan = useAppStore((s) => s.setViewerPan);
   const fitToViewTrigger = useAppStore((s) => s.fitToViewTrigger);
   const focusCropTrigger = useAppStore((s) => s.focusCropTrigger);
-  const canvasMode = useAppStore((s) => "canvasMode" in s.buildView ? s.buildView.canvasMode : "view");
+  const canvasMode = useAppStore((s) => getCanvasMode(s.buildView));
 
   const currentPage = currentSourcePages[currentPageIndex];
   const imageSrc = currentPage ? convertFileSrc(currentPage.file_path) : null;

--- a/src/components/build/NavigationBar.tsx
+++ b/src/components/build/NavigationBar.tsx
@@ -5,7 +5,7 @@ import { ANNOTATION_TOOL_LABELS } from "@/shared/types";
 import { flattenTrackSteps, getStepLabel, getReplacedStepIds } from "./tree-utils";
 
 export function NavigationBar() {
-  const navMode = useAppStore((s) => s.navMode);
+  const navMode = useAppStore((s) => s.buildView.kind === "building-page" ? "page" : "track");
 
   if (navMode === "page") {
     return <PageNavigationBar />;
@@ -20,7 +20,7 @@ function TrackNavigationBar() {
   const activeStepId = useAppStore((s) => s.activeStepId);
   const activeTrackId = useAppStore((s) => s.activeTrackId);
   const setActiveStep = useAppStore((s) => s.setActiveStep);
-  const annotationMode = useAppStore((s) => s.annotationMode);
+  const annotationMode = useAppStore((s) => s.buildView.kind === "building-track" ? s.buildView.annotationMode : null);
 
   const activeTrack = tracks.find((t) => t.id === activeTrackId);
 

--- a/src/components/build/NavigationBar.tsx
+++ b/src/components/build/NavigationBar.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useAppStore } from "@/store";
-import { ANNOTATION_TOOL_LABELS } from "@/shared/types";
+import { ANNOTATION_TOOL_LABELS, getAnnotationMode } from "@/shared/types";
 import { flattenTrackSteps, getStepLabel, getReplacedStepIds } from "./tree-utils";
 
 export function NavigationBar() {
@@ -20,7 +20,7 @@ function TrackNavigationBar() {
   const activeStepId = useAppStore((s) => s.activeStepId);
   const activeTrackId = useAppStore((s) => s.activeTrackId);
   const setActiveStep = useAppStore((s) => s.setActiveStep);
-  const annotationMode = useAppStore((s) => s.buildView.kind === "building-track" ? s.buildView.annotationMode : null);
+  const annotationMode = useAppStore((s) => getAnnotationMode(s.buildView));
 
   const activeTrack = tracks.find((t) => t.id === activeTrackId);
 

--- a/src/components/build/PolygonLayer.tsx
+++ b/src/components/build/PolygonLayer.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from "@/store";
 import { imagePointToEffective, effectivePointToImage } from "./CropLayer";
 import { useTheme } from "@/hooks/useTheme";
 import type { Step } from "@/shared/types";
+import { getCanvasMode } from "@/shared/types";
 import type Konva from "konva";
 
 interface PolygonLayerProps {
@@ -22,7 +23,7 @@ export function PolygonLayer({ zoom, stageRef }: PolygonLayerProps) {
   const tracks = useAppStore((s) => s.tracks);
   const currentSourcePages = useAppStore((s) => s.currentSourcePages);
   const currentPageIndex = useAppStore((s) => s.currentPageIndex);
-  const canvasMode = useAppStore((s) => "canvasMode" in s.buildView ? s.buildView.canvasMode : "view");
+  const canvasMode = useAppStore((s) => getCanvasMode(s.buildView));
   const polygonDraftPoints = useAppStore((s) => s.polygonDraftPoints);
   const polygonDraftStepId = useAppStore((s) => s.polygonDraftStepId);
   const activeStepId = useAppStore((s) => s.activeStepId);

--- a/src/components/build/PolygonLayer.tsx
+++ b/src/components/build/PolygonLayer.tsx
@@ -22,7 +22,7 @@ export function PolygonLayer({ zoom, stageRef }: PolygonLayerProps) {
   const tracks = useAppStore((s) => s.tracks);
   const currentSourcePages = useAppStore((s) => s.currentSourcePages);
   const currentPageIndex = useAppStore((s) => s.currentPageIndex);
-  const canvasMode = useAppStore((s) => s.canvasMode);
+  const canvasMode = useAppStore((s) => "canvasMode" in s.buildView ? s.buildView.canvasMode : "view");
   const polygonDraftPoints = useAppStore((s) => s.polygonDraftPoints);
   const polygonDraftStepId = useAppStore((s) => s.polygonDraftStepId);
   const activeStepId = useAppStore((s) => s.activeStepId);

--- a/src/hooks/useBuildingKeyboard.ts
+++ b/src/hooks/useBuildingKeyboard.ts
@@ -1,0 +1,79 @@
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { useAppStore } from "@/store";
+import { flattenTrackSteps, getReplacedStepIds } from "@/components/build/tree-utils";
+import { getEffectiveDryingMinutes } from "@/shared/types";
+
+export function useBuildingKeyboard() {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      const s = useAppStore.getState();
+      if (s.buildMode !== "building") return;
+
+      // Ctrl/Cmd+Shift+Z: redo annotation
+      if (e.key === "z" && (e.ctrlKey || e.metaKey) && e.shiftKey) {
+        e.preventDefault();
+        if (s.activeStepId) s.redoAnnotation(s.activeStepId);
+        return;
+      }
+      // Ctrl/Cmd+Z: undo annotation
+      if (e.key === "z" && (e.ctrlKey || e.metaKey) && !e.shiftKey) {
+        e.preventDefault();
+        if (s.activeStepId) s.undoAnnotation(s.activeStepId);
+        return;
+      }
+
+      if ((e.key === " " || e.key === "Enter") && s.activeStepId) {
+        e.preventDefault();
+        s.requestStepCompletion(s.activeStepId);
+        return;
+      }
+      if (e.key === "a" || e.key === "A") {
+        e.preventDefault();
+        if (s.annotationMode) s.setAnnotationMode(null);
+        return;
+      }
+      if (e.key >= "1" && e.key <= "7") {
+        e.preventDefault();
+        const toolMap = ["checkmark", "circle", "arrow", "cross", "highlight", "freehand", "text"] as const;
+        const idx = parseInt(e.key) - 1;
+        s.setAnnotationMode(toolMap[idx]);
+        return;
+      }
+      if ((e.key === "t" || e.key === "T") && s.activeStepId) {
+        e.preventDefault();
+        const step = s.steps.find((st) => st.id === s.activeStepId);
+        if (step && !s.activeTimers.some((t) => t.step_id === step.id)) {
+          const mins = getEffectiveDryingMinutes(step);
+          if (mins) {
+            s.addTimer(step.id, step.title, mins);
+          } else {
+            toast.info("Use the Start Timer button to enter a duration");
+          }
+        }
+        return;
+      }
+      if (e.key === "ArrowLeft" || e.key === "ArrowUp" || e.key === "ArrowRight" || e.key === "ArrowDown") {
+        e.preventDefault();
+        if (s.navMode === "page" && (e.key === "ArrowLeft" || e.key === "ArrowRight")) {
+          if (e.key === "ArrowLeft") s.prevPage();
+          else s.nextPage();
+        } else {
+          const replacedIds = getReplacedStepIds(s.steps);
+          const ordered = flattenTrackSteps(s.steps, s.activeTrackId, { excludeReplacedIds: replacedIds });
+          const idx = ordered.findIndex((st) => st.id === s.activeStepId);
+          if ((e.key === "ArrowLeft" || e.key === "ArrowUp") && idx > 0) {
+            s.setActiveStep(ordered[idx - 1].id);
+          } else if ((e.key === "ArrowRight" || e.key === "ArrowDown") && idx >= 0 && idx < ordered.length - 1) {
+            s.setActiveStep(ordered[idx + 1].id);
+          }
+        }
+        return;
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+}

--- a/src/hooks/useBuildingKeyboard.ts
+++ b/src/hooks/useBuildingKeyboard.ts
@@ -9,7 +9,7 @@ export function useBuildingKeyboard() {
     const handler = (e: KeyboardEvent) => {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
       const s = useAppStore.getState();
-      if (s.buildMode !== "building") return;
+      if (s.buildView.kind !== "building-track" && s.buildView.kind !== "building-page") return;
 
       // Ctrl/Cmd+Shift+Z: redo annotation
       if (e.key === "z" && (e.ctrlKey || e.metaKey) && e.shiftKey) {
@@ -31,7 +31,7 @@ export function useBuildingKeyboard() {
       }
       if (e.key === "a" || e.key === "A") {
         e.preventDefault();
-        if (s.annotationMode) s.setAnnotationMode(null);
+        if (s.buildView.kind === "building-track" && s.buildView.annotationMode) s.setAnnotationMode(null);
         return;
       }
       if (e.key >= "1" && e.key <= "7") {
@@ -56,7 +56,7 @@ export function useBuildingKeyboard() {
       }
       if (e.key === "ArrowLeft" || e.key === "ArrowUp" || e.key === "ArrowRight" || e.key === "ArrowDown") {
         e.preventDefault();
-        if (s.navMode === "page" && (e.key === "ArrowLeft" || e.key === "ArrowRight")) {
+        if (s.buildView.kind === "building-page" && (e.key === "ArrowLeft" || e.key === "ArrowRight")) {
           if (e.key === "ArrowLeft") s.prevPage();
           else s.nextPage();
         } else {

--- a/src/hooks/useCropDrawing.ts
+++ b/src/hooks/useCropDrawing.ts
@@ -1,6 +1,7 @@
 import { useRef, useCallback, useState } from "react";
 import { toast } from "sonner";
 import { useAppStore } from "@/store";
+import { getCanvasMode } from "@/shared/types";
 import * as api from "@/api";
 import type Konva from "konva";
 
@@ -81,7 +82,7 @@ export function useCropDrawing(stageRef: React.RefObject<Konva.Stage | null>) {
   const startPoint = useRef<{ x: number; y: number } | null>(null);
   const isCreating = useRef(false);
 
-  const canvasMode = useAppStore((s) => "canvasMode" in s.buildView ? s.buildView.canvasMode : "view");
+  const canvasMode = useAppStore((s) => getCanvasMode(s.buildView));
   const activeTrackId = useAppStore((s) => s.activeTrackId);
   const activeStepId = useAppStore((s) => s.activeStepId);
   const currentSourcePages = useAppStore((s) => s.currentSourcePages);

--- a/src/hooks/useCropDrawing.ts
+++ b/src/hooks/useCropDrawing.ts
@@ -81,7 +81,7 @@ export function useCropDrawing(stageRef: React.RefObject<Konva.Stage | null>) {
   const startPoint = useRef<{ x: number; y: number } | null>(null);
   const isCreating = useRef(false);
 
-  const canvasMode = useAppStore((s) => s.canvasMode);
+  const canvasMode = useAppStore((s) => "canvasMode" in s.buildView ? s.buildView.canvasMode : "view");
   const activeTrackId = useAppStore((s) => s.activeTrackId);
   const activeStepId = useAppStore((s) => s.activeStepId);
   const currentSourcePages = useAppStore((s) => s.currentSourcePages);

--- a/src/hooks/useSetupKeyboard.ts
+++ b/src/hooks/useSetupKeyboard.ts
@@ -1,0 +1,106 @@
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { useAppStore } from "@/store";
+import * as api from "@/api";
+
+export function useSetupKeyboard() {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      const s = useAppStore.getState();
+      if (s.buildMode !== "setup") return;
+
+      // Ctrl/Cmd+Z: undo last crop
+      if (e.key === "z" && (e.ctrlKey || e.metaKey) && !e.shiftKey) {
+        e.preventDefault();
+        s.undoLastCrop();
+        return;
+      }
+
+      switch (e.key) {
+        case "ArrowLeft":
+          e.preventDefault();
+          s.prevPage();
+          return;
+        case "ArrowRight":
+          e.preventDefault();
+          s.nextPage();
+          return;
+        case "Enter":
+          if (s.canvasMode === "polygon" && s.polygonDraftPoints.length >= 3) {
+            e.preventDefault();
+            s.savePolygon();
+          }
+          return;
+        case "c":
+        case "C":
+          e.preventDefault();
+          s.setCanvasMode("crop");
+          return;
+        case "p":
+        case "P":
+          e.preventDefault();
+          s.setCanvasMode("polygon");
+          return;
+        case "v":
+          e.preventDefault();
+          s.setCanvasMode("view");
+          return;
+        case "f":
+        case "F": {
+          e.preventDefault();
+          const page = s.currentSourcePages[s.currentPageIndex];
+          if (!s.activeTrackId) {
+            toast.info("Select a track first");
+            return;
+          }
+          if (!page) return;
+          const trackSteps = s.steps.filter((st) => st.track_id === s.activeTrackId);
+          const rootCount = trackSteps.filter((st) => !st.parent_step_id).length;
+          const title = `Step ${rootCount + 1}`;
+          api
+            .createStep({
+              track_id: s.activeTrackId,
+              title,
+              source_page_id: page.id,
+              is_full_page: true,
+              crop_x: 0,
+              crop_y: 0,
+              crop_w: page.width,
+              crop_h: page.height,
+            })
+            .then((step) => {
+              const fresh = useAppStore.getState();
+              fresh.addStep(step);
+              fresh.pushUndo(step.id);
+              fresh.setActiveStep(step.id);
+              fresh.triggerAutoDetect(step.id);
+              if (fresh.activeProjectId) fresh.loadTracks(fresh.activeProjectId);
+              toast.success("Step created", { toasterId: "canvas" });
+            })
+            .catch((err) => toast.error(`Failed to create step: ${err}`, { toasterId: "canvas" }));
+          return;
+        }
+        case "Escape":
+          e.preventDefault();
+          if (s.canvasMode === "polygon") {
+            if (s.polygonDraftPoints.length > 0) {
+              s.removeLastPolygonPoint();
+            } else {
+              s.setCanvasMode("view");
+            }
+          } else if (s.selectedStepIds.length > 0) {
+            s.clearSelectedSteps();
+          } else if (s.activeStepId) {
+            s.setActiveStep(null);
+          } else if (s.canvasMode === "crop") {
+            s.setCanvasMode("view");
+          }
+          return;
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+}

--- a/src/hooks/useSetupKeyboard.ts
+++ b/src/hooks/useSetupKeyboard.ts
@@ -8,7 +8,7 @@ export function useSetupKeyboard() {
     const handler = (e: KeyboardEvent) => {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
       const s = useAppStore.getState();
-      if (s.buildMode !== "setup") return;
+      if (s.buildView.kind !== "setup-tracks" && s.buildView.kind !== "setup-sprues") return;
 
       // Ctrl/Cmd+Z: undo last crop
       if (e.key === "z" && (e.ctrlKey || e.metaKey) && !e.shiftKey) {
@@ -27,7 +27,7 @@ export function useSetupKeyboard() {
           s.nextPage();
           return;
         case "Enter":
-          if (s.canvasMode === "polygon" && s.polygonDraftPoints.length >= 3) {
+          if ("canvasMode" in s.buildView && s.buildView.canvasMode === "polygon" && s.polygonDraftPoints.length >= 3) {
             e.preventDefault();
             s.savePolygon();
           }
@@ -83,7 +83,7 @@ export function useSetupKeyboard() {
         }
         case "Escape":
           e.preventDefault();
-          if (s.canvasMode === "polygon") {
+          if ("canvasMode" in s.buildView && s.buildView.canvasMode === "polygon") {
             if (s.polygonDraftPoints.length > 0) {
               s.removeLastPolygonPoint();
             } else {
@@ -93,7 +93,7 @@ export function useSetupKeyboard() {
             s.clearSelectedSteps();
           } else if (s.activeStepId) {
             s.setActiveStep(null);
-          } else if (s.canvasMode === "crop") {
+          } else if ("canvasMode" in s.buildView && s.buildView.canvasMode === "crop") {
             s.setCanvasMode("view");
           }
           return;

--- a/src/hooks/useSetupKeyboard.ts
+++ b/src/hooks/useSetupKeyboard.ts
@@ -1,7 +1,5 @@
 import { useEffect } from "react";
-import { toast } from "sonner";
 import { useAppStore } from "@/store";
-import * as api from "@/api";
 
 export function useSetupKeyboard() {
   useEffect(() => {
@@ -47,40 +45,10 @@ export function useSetupKeyboard() {
           s.setCanvasMode("view");
           return;
         case "f":
-        case "F": {
+        case "F":
           e.preventDefault();
-          const page = s.currentSourcePages[s.currentPageIndex];
-          if (!s.activeTrackId) {
-            toast.info("Select a track first");
-            return;
-          }
-          if (!page) return;
-          const trackSteps = s.steps.filter((st) => st.track_id === s.activeTrackId);
-          const rootCount = trackSteps.filter((st) => !st.parent_step_id).length;
-          const title = `Step ${rootCount + 1}`;
-          api
-            .createStep({
-              track_id: s.activeTrackId,
-              title,
-              source_page_id: page.id,
-              is_full_page: true,
-              crop_x: 0,
-              crop_y: 0,
-              crop_w: page.width,
-              crop_h: page.height,
-            })
-            .then((step) => {
-              const fresh = useAppStore.getState();
-              fresh.addStep(step);
-              fresh.pushUndo(step.id);
-              fresh.setActiveStep(step.id);
-              fresh.triggerAutoDetect(step.id);
-              if (fresh.activeProjectId) fresh.loadTracks(fresh.activeProjectId);
-              toast.success("Step created", { toasterId: "canvas" });
-            })
-            .catch((err) => toast.error(`Failed to create step: ${err}`, { toasterId: "canvas" }));
+          s.createFullPageStep();
           return;
-        }
         case "Escape":
           e.preventDefault();
           if ("canvasMode" in s.buildView && s.buildView.canvasMode === "polygon") {

--- a/src/hooks/useSharedKeyboard.ts
+++ b/src/hooks/useSharedKeyboard.ts
@@ -1,0 +1,47 @@
+import { useEffect } from "react";
+import { useAppStore } from "@/store";
+import { zoomIn, zoomOut } from "@/components/build/zoom-utils";
+
+export function useSharedKeyboard(onOpenShortcuts: () => void) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (e.ctrlKey || e.metaKey) return; // let other hooks handle Ctrl combos
+
+      const s = useAppStore.getState();
+
+      switch (e.key) {
+        case "?":
+          e.preventDefault();
+          onOpenShortcuts();
+          return;
+        case "Tab":
+          e.preventDefault();
+          if (e.shiftKey) s.prevPage();
+          else s.nextPage();
+          return;
+        case "+":
+        case "=":
+          e.preventDefault();
+          zoomIn();
+          return;
+        case "-":
+          e.preventDefault();
+          zoomOut();
+          return;
+        case "0":
+          e.preventDefault();
+          s.requestFitToView();
+          return;
+        case "r":
+        case "R":
+          e.preventDefault();
+          s.rotatePage();
+          return;
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onOpenShortcuts]);
+}

--- a/src/hooks/useSprueDrawing.ts
+++ b/src/hooks/useSprueDrawing.ts
@@ -1,6 +1,7 @@
 import { useRef, useCallback, useState } from "react";
 import { toast } from "sonner";
 import { useAppStore } from "@/store";
+import { getCanvasMode } from "@/shared/types";
 import { stageToImage } from "./useCropDrawing";
 import type { DrawingRect } from "./useCropDrawing";
 import * as api from "@/api";
@@ -20,7 +21,7 @@ export function useSprueDrawing(stageRef: React.RefObject<Konva.Stage | null>) {
   const startPoint = useRef<{ x: number; y: number } | null>(null);
   const isCreating = useRef(false);
 
-  const canvasMode = useAppStore((s) => "canvasMode" in s.buildView ? s.buildView.canvasMode : "view");
+  const canvasMode = useAppStore((s) => getCanvasMode(s.buildView));
   const setupRailMode = useAppStore((s) => s.buildView.kind === "setup-sprues" ? "sprues" : "steps");
   const activeSprueRefId = useAppStore((s) => s.activeSprueRefId);
   const sprueRefs = useAppStore((s) => s.sprueRefs);

--- a/src/hooks/useSprueDrawing.ts
+++ b/src/hooks/useSprueDrawing.ts
@@ -20,8 +20,8 @@ export function useSprueDrawing(stageRef: React.RefObject<Konva.Stage | null>) {
   const startPoint = useRef<{ x: number; y: number } | null>(null);
   const isCreating = useRef(false);
 
-  const canvasMode = useAppStore((s) => s.canvasMode);
-  const setupRailMode = useAppStore((s) => s.setupRailMode);
+  const canvasMode = useAppStore((s) => "canvasMode" in s.buildView ? s.buildView.canvasMode : "view");
+  const setupRailMode = useAppStore((s) => s.buildView.kind === "setup-sprues" ? "sprues" : "steps");
   const activeSprueRefId = useAppStore((s) => s.activeSprueRefId);
   const sprueRefs = useAppStore((s) => s.sprueRefs);
   const activeProjectId = useAppStore((s) => s.activeProjectId);

--- a/src/routes/build.tsx
+++ b/src/routes/build.tsx
@@ -1,9 +1,7 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Wrench, Plus } from "lucide-react";
-import { toast } from "sonner";
 import { Toaster } from "@/components/ui/sonner";
 import { useAppStore } from "@/store";
-import * as api from "@/api";
 import { CreateProjectDialog } from "@/components/shared/CreateProjectDialog";
 import { Button } from "@/components/ui/button";
 import { BuildToolbar } from "@/components/build/BuildToolbar";
@@ -29,10 +27,10 @@ import { CompletionWarningDialog } from "@/components/build/CompletionWarningDia
 import { PolygonSwitchDialog } from "@/components/build/PolygonSwitchDialog";
 import { RelationPill } from "@/components/build/RelationPill";
 import { TimerBubble } from "@/components/build/TimerBubble";
-import { flattenTrackSteps, getReplacedStepIds } from "@/components/build/tree-utils";
 import { useUploadPdf } from "@/components/build/useUploadPdf";
-import { getEffectiveDryingMinutes } from "@/shared/types";
-import { zoomIn, zoomOut } from "@/components/build/zoom-utils";
+import { useSharedKeyboard } from "@/hooks/useSharedKeyboard";
+import { useSetupKeyboard } from "@/hooks/useSetupKeyboard";
+import { useBuildingKeyboard } from "@/hooks/useBuildingKeyboard";
 
 export default function BuildRoute() {
   // Only subscribe to state needed for rendering layout decisions
@@ -65,210 +63,11 @@ export default function BuildRoute() {
     if (isProcessingPdf) setSourceManagerOpen(false);
   }, [isProcessingPdf]);
 
-  // Keyboard navigation — reads store state on-demand via getState()
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (
-        e.target instanceof HTMLInputElement ||
-        e.target instanceof HTMLTextAreaElement
-      ) {
-        return;
-      }
-
-      const s = useAppStore.getState();
-
-      // Ctrl/Cmd+Shift+Z: redo annotation (building mode only)
-      if (e.key === "z" && (e.ctrlKey || e.metaKey) && e.shiftKey) {
-        e.preventDefault();
-        if (s.buildMode === "building" && s.activeStepId) {
-          s.redoAnnotation(s.activeStepId);
-        }
-        return;
-      }
-      // Ctrl/Cmd+Z: undo annotation (building) or undo last crop (setup)
-      if (e.key === "z" && (e.ctrlKey || e.metaKey) && !e.shiftKey) {
-        e.preventDefault();
-        if (s.buildMode === "building" && s.activeStepId) {
-          s.undoAnnotation(s.activeStepId);
-        } else {
-          s.undoLastCrop();
-        }
-        return;
-      }
-
-      if (e.key === "?") {
-        e.preventDefault();
-        setShortcutsOpen(true);
-        return;
-      }
-
-      // Building mode navigation + completion
-      if (s.buildMode === "building") {
-        if ((e.key === " " || e.key === "Enter") && s.activeStepId) {
-          e.preventDefault();
-          s.requestStepCompletion(s.activeStepId);
-          return;
-        }
-        if (e.key === "a" || e.key === "A") {
-          e.preventDefault();
-          if (s.annotationMode) s.setAnnotationMode(null);
-          return;
-        }
-        if (e.key >= "1" && e.key <= "7") {
-          e.preventDefault();
-          const toolMap = ["checkmark", "circle", "arrow", "cross", "highlight", "freehand", "text"] as const;
-          const idx = parseInt(e.key) - 1;
-          s.setAnnotationMode(toolMap[idx]);
-          return;
-        }
-        if ((e.key === "t" || e.key === "T") && s.activeStepId) {
-          e.preventDefault();
-          const step = s.steps.find((st) => st.id === s.activeStepId);
-          if (step && !s.activeTimers.some((t) => t.step_id === step.id)) {
-            const mins = getEffectiveDryingMinutes(step);
-            if (mins) {
-              s.addTimer(step.id, step.title, mins);
-            } else {
-              toast.info("Use the Start Timer button to enter a duration");
-            }
-          }
-          return;
-        }
-        if (e.key === "ArrowLeft" || e.key === "ArrowUp" || e.key === "ArrowRight" || e.key === "ArrowDown") {
-          e.preventDefault();
-          if (s.navMode === "page" && (e.key === "ArrowLeft" || e.key === "ArrowRight")) {
-            if (e.key === "ArrowLeft") s.prevPage();
-            else s.nextPage();
-          } else {
-            const replacedIds = getReplacedStepIds(s.steps);
-            const ordered = flattenTrackSteps(s.steps, s.activeTrackId, { excludeReplacedIds: replacedIds });
-            const idx = ordered.findIndex((st) => st.id === s.activeStepId);
-            if ((e.key === "ArrowLeft" || e.key === "ArrowUp") && idx > 0) {
-              s.setActiveStep(ordered[idx - 1].id);
-            } else if ((e.key === "ArrowRight" || e.key === "ArrowDown") && idx >= 0 && idx < ordered.length - 1) {
-              s.setActiveStep(ordered[idx + 1].id);
-            }
-          }
-          return;
-        }
-      }
-
-      // Setup mode: arrow keys navigate pages
-      if (s.buildMode === "setup" && (e.key === "ArrowLeft" || e.key === "ArrowRight")) {
-        e.preventDefault();
-        if (e.key === "ArrowLeft") {
-          s.prevPage();
-        } else {
-          s.nextPage();
-        }
-        return;
-      }
-
-      switch (e.key) {
-        case "Enter":
-          if (s.canvasMode === "polygon" && s.polygonDraftPoints.length >= 3) {
-            e.preventDefault();
-            s.savePolygon();
-          }
-          break;
-        case "Tab":
-          e.preventDefault();
-          if (e.shiftKey) {
-            s.prevPage();
-          } else {
-            s.nextPage();
-          }
-          break;
-        case "+":
-        case "=":
-          e.preventDefault();
-          zoomIn();
-          break;
-        case "-":
-          e.preventDefault();
-          zoomOut();
-          break;
-        case "0":
-          e.preventDefault();
-          s.requestFitToView();
-          break;
-        case "r":
-        case "R":
-          e.preventDefault();
-          s.rotatePage();
-          break;
-        case "c":
-        case "C":
-          e.preventDefault();
-          if (s.buildMode === "setup") s.setCanvasMode("crop");
-          break;
-        case "p":
-        case "P":
-          e.preventDefault();
-          if (s.buildMode === "setup") s.setCanvasMode("polygon");
-          break;
-        case "v":
-          e.preventDefault();
-          s.setCanvasMode("view");
-          break;
-        case "f":
-        case "F": {
-          e.preventDefault();
-          if (s.buildMode === "building") break;
-          const page = s.currentSourcePages[s.currentPageIndex];
-          if (!s.activeTrackId) {
-            toast.info("Select a track first");
-            break;
-          }
-          if (!page) break;
-          const trackSteps = s.steps.filter((st) => st.track_id === s.activeTrackId);
-          const rootCount = trackSteps.filter((st) => !st.parent_step_id).length;
-          const title = `Step ${rootCount + 1}`;
-          api
-            .createStep({
-              track_id: s.activeTrackId,
-              title,
-              source_page_id: page.id,
-              is_full_page: true,
-              crop_x: 0,
-              crop_y: 0,
-              crop_w: page.width,
-              crop_h: page.height,
-            })
-            .then((step) => {
-              const fresh = useAppStore.getState();
-              fresh.addStep(step);
-              fresh.pushUndo(step.id);
-              fresh.setActiveStep(step.id);
-              fresh.triggerAutoDetect(step.id);
-              if (fresh.activeProjectId) fresh.loadTracks(fresh.activeProjectId);
-              toast.success("Step created", { toasterId: "canvas" });
-            })
-            .catch((err) => toast.error(`Failed to create step: ${err}`, { toasterId: "canvas" }));
-          break;
-        }
-        case "Escape":
-          e.preventDefault();
-          if (s.canvasMode === "polygon") {
-            if (s.polygonDraftPoints.length > 0) {
-              s.removeLastPolygonPoint();
-            } else {
-              s.setCanvasMode("view");
-            }
-          } else if (s.selectedStepIds.length > 0) {
-            s.clearSelectedSteps();
-          } else if (s.activeStepId) {
-            s.setActiveStep(null);
-          } else if (s.canvasMode === "crop") {
-            s.setCanvasMode("view");
-          }
-          break;
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps -- reads state on-demand via getState()
+  // Keyboard hooks (each registers its own window listener, reads state on-demand)
+  const openShortcuts = useCallback(() => setShortcutsOpen(true), []);
+  useSharedKeyboard(openShortcuts);
+  useSetupKeyboard();
+  useBuildingKeyboard();
 
   if (!project) {
     return (

--- a/src/routes/build.tsx
+++ b/src/routes/build.tsx
@@ -35,15 +35,15 @@ import { useBuildingKeyboard } from "@/hooks/useBuildingKeyboard";
 export default function BuildRoute() {
   // Only subscribe to state needed for rendering layout decisions
   const project = useAppStore((s) => s.project);
-  const buildMode = useAppStore((s) => s.buildMode);
+  const buildView = useAppStore((s) => s.buildView);
   const instructionSources = useAppStore((s) => s.instructionSources);
   const isProcessingPdf = useAppStore((s) => s.isProcessingPdf);
   const activeStepId = useAppStore((s) => s.activeStepId);
-  const navMode = useAppStore((s) => s.navMode);
-  const setupRailMode = useAppStore((s) => s.setupRailMode);
   const loadTimers = useAppStore((s) => s.loadTimers);
   const activeProjectId = useAppStore((s) => s.activeProjectId);
   const refreshPaletteEntries = useAppStore((s) => s.refreshProjectPaletteEntries);
+
+  const isSetup = buildView.kind === "setup-tracks" || buildView.kind === "setup-sprues";
 
   // Load timers and refresh palette entries on mount
   useEffect(() => {
@@ -107,9 +107,9 @@ export default function BuildRoute() {
       />
 
       <div className="flex flex-1 overflow-hidden">
-        {buildMode === "setup" ? (
+        {isSetup ? (
           <>
-            {setupRailMode === "sprues" ? <SprueRail /> : <TrackRail />}
+            {buildView.kind === "setup-sprues" ? <SprueRail /> : <TrackRail />}
 
             <div className="relative flex min-w-0 flex-1 flex-col bg-[#E8E4DF]">
               <div className="relative min-h-0 flex-1">
@@ -141,18 +141,18 @@ export default function BuildRoute() {
           </>
         ) : (
           <>
-            {navMode === "track" ? <BuildingRail /> : <PageRail />}
+            {buildView.kind === "building-track" ? <BuildingRail /> : <PageRail />}
 
             <div className="relative flex min-w-0 flex-1 flex-col bg-[#E8E4DF]">
               <div className="relative min-h-0 flex-1">
-                {navMode === "track" ? <CropCanvas /> : <PageCanvas />}
-                {navMode === "track" && <AnnotationToolbar />}
+                {buildView.kind === "building-track" ? <CropCanvas /> : <PageCanvas />}
+                {buildView.kind === "building-track" && <AnnotationToolbar />}
                 <RelationPill />
               </div>
               <NavigationBar />
             </div>
 
-            {navMode === "page" ? <PageInfoPanel /> : activeStepId && <BuildingStepPanel />}
+            {buildView.kind === "building-page" ? <PageInfoPanel /> : activeStepId && <BuildingStepPanel />}
             <MilestoneDialog />
             <CompletionWarningDialog />
             <PolygonSwitchDialog />

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -708,11 +708,43 @@ export interface ProjectUiState {
   active_track_id: string | null;
   build_mode: "setup" | "building";
   nav_mode: "track" | "page";
+  build_view: string | null;
   image_zoom: number;
   image_pan_x: number;
   image_pan_y: number;
   sprue_panel_open: boolean;
   updated_at: number;
+}
+
+// ── Build View (discriminated union for mode state) ─────────────────────────
+
+export type BuildView =
+  | { kind: "setup-tracks"; canvasMode: "view" | "crop" | "polygon" }
+  | { kind: "setup-sprues"; canvasMode: "view" | "crop" }
+  | { kind: "building-track"; annotationMode: AnnotationTool }
+  | { kind: "building-page" };
+
+export function parseBuildView(json: string | null): BuildView | null {
+  if (!json) return null;
+  try {
+    const parsed = JSON.parse(json) as BuildView;
+    if (parsed && typeof parsed.kind === "string") return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function buildViewFromLegacy(
+  buildMode: "setup" | "building",
+  navMode: "track" | "page",
+): BuildView {
+  if (buildMode === "building") {
+    return navMode === "page"
+      ? { kind: "building-page" }
+      : { kind: "building-track", annotationMode: null };
+  }
+  return { kind: "setup-tracks", canvasMode: "view" };
 }
 
 export type Zone = "collection" | "build" | "overview";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -724,6 +724,21 @@ export type BuildView =
   | { kind: "building-track"; annotationMode: AnnotationTool }
   | { kind: "building-page" };
 
+export function getCanvasMode(view: BuildView): "view" | "crop" | "polygon" {
+  return "canvasMode" in view ? view.canvasMode : "view";
+}
+
+export function getAnnotationMode(view: BuildView): AnnotationTool {
+  return view.kind === "building-track" ? view.annotationMode : null;
+}
+
+export function buildViewsEqual(a: BuildView, b: BuildView): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "building-track" && b.kind === "building-track") return a.annotationMode === b.annotationMode;
+  if ("canvasMode" in a && "canvasMode" in b) return a.canvasMode === b.canvasMode;
+  return true;
+}
+
 export function parseBuildView(json: string | null): BuildView | null {
   if (!json) return null;
   try {

--- a/src/store/build-slice.ts
+++ b/src/store/build-slice.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from "zustand";
 import type { Project, UpdateProjectInput, UpdateStepInput, InstructionSource, InstructionPage, Track, Step, ReferenceImage, Annotation, AnnotationTool, PaletteEntry, SprueRef, StepSpruePart, StepContext, BuildView } from "@/shared/types";
-import { getEffectiveDryingMinutes, ANNOTATION_TOOL_LABELS, getSettingBool, parseBuildView, buildViewFromLegacy } from "@/shared/types";
+import { getEffectiveDryingMinutes, buildViewsEqual, ANNOTATION_TOOL_LABELS, getSettingBool, parseBuildView, buildViewFromLegacy } from "@/shared/types";
 import type { AppStore } from "./index";
 import * as api from "@/api";
 import { toast } from "sonner";
@@ -238,6 +238,9 @@ export interface BuildSlice {
   confirmPolygonSave: () => Promise<void>;
   dismissPolygonSwitch: () => void;
   clearClipPolygon: (stepId: string) => Promise<void>;
+
+  // Full-page step (shared by toolbar + keyboard shortcut)
+  createFullPageStep: () => Promise<void>;
 
   // AI detection
   triggerAutoDetect: (stepId: string) => void;
@@ -894,6 +897,7 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
   },
 
   setAnnotationMode: (mode) => {
+    if (mode === get().annotationMode) return;
     set({
       annotationMode: mode,
       buildView: { kind: "building-track", annotationMode: mode },
@@ -1226,8 +1230,41 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
       }
     }
 
-    if (projectId) {
+    if (projectId && !buildViewsEqual(prevView, view)) {
       api.saveBuildView(projectId, view).catch((e) => toast.error(`Failed to save view state: ${e}`));
+    }
+  },
+
+  createFullPageStep: async () => {
+    const s = get();
+    if (!s.activeTrackId) {
+      toast.info("Select a track first");
+      return;
+    }
+    const page = s.currentSourcePages[s.currentPageIndex];
+    if (!page) return;
+    const trackSteps = s.steps.filter((st) => st.track_id === s.activeTrackId);
+    const rootCount = trackSteps.filter((st) => !st.parent_step_id).length;
+    try {
+      const step = await api.createStep({
+        track_id: s.activeTrackId!,
+        title: `Step ${rootCount + 1}`,
+        source_page_id: page.id,
+        is_full_page: true,
+        crop_x: 0,
+        crop_y: 0,
+        crop_w: page.width,
+        crop_h: page.height,
+      });
+      const fresh = get();
+      fresh.addStep(step);
+      fresh.pushUndo(step.id);
+      fresh.setActiveStep(step.id);
+      fresh.triggerAutoDetect(step.id);
+      if (fresh.activeProjectId) fresh.loadTracks(fresh.activeProjectId);
+      toast.success("Step created", { toasterId: "canvas" });
+    } catch (e) {
+      toast.error(`Failed to create step: ${e}`, { toasterId: "canvas" });
     }
   },
 

--- a/src/store/build-slice.ts
+++ b/src/store/build-slice.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from "zustand";
-import type { Project, UpdateProjectInput, UpdateStepInput, InstructionSource, InstructionPage, Track, Step, ReferenceImage, Annotation, AnnotationTool, PaletteEntry, SprueRef, StepSpruePart, StepContext } from "@/shared/types";
-import { getEffectiveDryingMinutes, ANNOTATION_TOOL_LABELS, getSettingBool } from "@/shared/types";
+import type { Project, UpdateProjectInput, UpdateStepInput, InstructionSource, InstructionPage, Track, Step, ReferenceImage, Annotation, AnnotationTool, PaletteEntry, SprueRef, StepSpruePart, StepContext, BuildView } from "@/shared/types";
+import { getEffectiveDryingMinutes, ANNOTATION_TOOL_LABELS, getSettingBool, parseBuildView, buildViewFromLegacy } from "@/shared/types";
 import type { AppStore } from "./index";
 import * as api from "@/api";
 import { toast } from "sonner";
@@ -197,7 +197,11 @@ export interface BuildSlice {
   resetViewerState: () => void;
   requestFitToView: () => void;
 
-  // Build mode
+  // Build view (discriminated union — new primary state)
+  buildView: BuildView;
+  setBuildView: (view: BuildView) => void;
+
+  // Build mode (legacy — dual-written from buildView)
   buildMode: BuildMode;
   setBuildMode: (mode: BuildMode) => void;
   completeActiveStep: () => Promise<void>;
@@ -276,6 +280,7 @@ const DEFAULT_BUILD_STATE = {
   annotationStrokeWidth: 0.003,
   annotationUndoStacks: {} as Record<string, Annotation[][]>,
   annotationRedoStacks: {} as Record<string, Annotation[][]>,
+  buildView: { kind: "setup-tracks", canvasMode: "view" } as BuildView,
   buildMode: "setup" as BuildMode,
   setupRailMode: "steps" as SetupRailMode,
   navMode: "track" as NavMode,
@@ -372,10 +377,13 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
       api.getProject(id),
       api.getProjectUiState(id),
     ]);
+    const buildView = parseBuildView(uiState.build_view)
+      ?? buildViewFromLegacy(uiState.build_mode as "setup" | "building", uiState.nav_mode as "track" | "page");
     set({
       activeProjectId: id,
       project,
       ...DEFAULT_BUILD_STATE,
+      buildView,
       buildMode: uiState.build_mode === "building" ? "building" : "setup",
       navMode: uiState.nav_mode === "page" ? "page" : "track",
       activeTrackId: uiState.active_track_id ?? null,
@@ -410,9 +418,12 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
     const project = await api.getActiveProject();
     if (project) {
       const uiState = await api.getProjectUiState(project.id);
+      const buildView = parseBuildView(uiState.build_view)
+        ?? buildViewFromLegacy(uiState.build_mode as "setup" | "building", uiState.nav_mode as "track" | "page");
       set({
         activeProjectId: project.id,
         project,
+        buildView,
         buildMode: uiState.build_mode === "building" ? "building" : "setup",
         navMode: uiState.nav_mode === "page" ? "page" : "track",
         activeTrackId: uiState.active_track_id ?? null,
@@ -889,7 +900,12 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
     get().saveAnnotationsDebounced(stepId);
   },
 
-  setAnnotationMode: (mode) => set({ annotationMode: mode }),
+  setAnnotationMode: (mode) => {
+    set({
+      annotationMode: mode,
+      buildView: { kind: "building-track", annotationMode: mode },
+    });
+  },
   setAnnotationColor: (color) => {
     set({ annotationColor: color });
     api.setSetting("annotation_color", color).catch((e) => toast.error(`Failed to save setting: ${e}`));
@@ -1166,6 +1182,28 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
     set({ pendingCompletion: null });
   },
 
+  setBuildView: (view) => {
+    const projectId = get().activeProjectId;
+    // Dual-write to legacy fields
+    const isSetup = view.kind === "setup-tracks" || view.kind === "setup-sprues";
+    const legacyBuildMode: BuildMode = isSetup ? "setup" : "building";
+    const legacyNavMode: NavMode = view.kind === "building-page" ? "page" : "track";
+    const legacyCanvasMode: CanvasMode = ("canvasMode" in view ? view.canvasMode : "view") as CanvasMode;
+    const legacyAnnotationMode: AnnotationTool = view.kind === "building-track" ? view.annotationMode : null;
+    const legacySetupRailMode: SetupRailMode = view.kind === "setup-sprues" ? "sprues" : "steps";
+    set({
+      buildView: view,
+      buildMode: legacyBuildMode,
+      navMode: legacyNavMode,
+      canvasMode: legacyCanvasMode,
+      annotationMode: legacyAnnotationMode,
+      setupRailMode: legacySetupRailMode,
+    });
+    if (projectId) {
+      api.saveBuildView(projectId, view).catch((e) => toast.error(`Failed to save view state: ${e}`));
+    }
+  },
+
   setBuildMode: async (mode) => {
     const state = get();
     const projectId = state.activeProjectId;
@@ -1195,6 +1233,15 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
       updates.annotationMode = null as AnnotationTool;
     }
 
+    // Dual-write buildView
+    if (mode === "building") {
+      updates.buildView = state.navMode === "page"
+        ? { kind: "building-page" }
+        : { kind: "building-track", annotationMode: null };
+    } else {
+      updates.buildView = { kind: "setup-tracks", canvasMode: "view" };
+    }
+
     set(updates);
 
     // Load step context for active step when entering building mode
@@ -1206,21 +1253,31 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
     }
     try {
       await api.saveBuildMode(projectId, mode);
+      if (updates.buildView) api.saveBuildView(projectId, updates.buildView).catch(() => {});
     } catch (e) {
       toast.error(`Failed to save build mode: ${e}`);
     }
   },
 
   setSetupRailMode: (mode) => {
-    set({ setupRailMode: mode });
+    const bv: BuildView = mode === "sprues"
+      ? { kind: "setup-sprues", canvasMode: "view" }
+      : { kind: "setup-tracks", canvasMode: get().canvasMode === "polygon" || get().canvasMode === "crop" ? get().canvasMode : "view" };
+    set({ setupRailMode: mode, buildView: bv });
+    const projectId = get().activeProjectId;
+    if (projectId) api.saveBuildView(projectId, bv).catch(() => {});
   },
 
   setNavMode: async (mode) => {
     const projectId = get().activeProjectId;
-    set({ navMode: mode });
+    const bv: BuildView = mode === "page"
+      ? { kind: "building-page" }
+      : { kind: "building-track", annotationMode: get().annotationMode };
+    set({ navMode: mode, buildView: bv });
     if (projectId) {
       try {
         await api.saveNavMode(projectId, mode);
+        api.saveBuildView(projectId, bv).catch(() => {});
       } catch (e) {
         toast.error(`Failed to save nav mode: ${e}`);
       }
@@ -1244,6 +1301,13 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
       toast.info("Select a track first");
       return;
     }
+    // Compute buildView for dual-write
+    const bvCanvasMode = get().setupRailMode === "sprues"
+      ? (mode === "crop" || mode === "view" ? mode : "view") as "view" | "crop"
+      : mode;
+    const bv: BuildView = get().setupRailMode === "sprues"
+      ? { kind: "setup-sprues", canvasMode: bvCanvasMode as "view" | "crop" }
+      : { kind: "setup-tracks", canvasMode: bvCanvasMode };
     if (mode === "polygon") {
       if (!get().activeTrackId) {
         toast.info("Select a track first");
@@ -1256,6 +1320,7 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
         const existing: { x: number; y: number }[] = JSON.parse(step.clip_polygon);
         set({
           canvasMode: mode,
+          buildView: bv,
           polygonDraftPoints: existing,
           polygonDraftStepId: step.id,
         });
@@ -1263,6 +1328,7 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
         // No existing polygon — create new step on save
         set({
           canvasMode: mode,
+          buildView: bv,
           polygonDraftPoints: [],
           polygonDraftStepId: null,
         });
@@ -1271,9 +1337,9 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
     }
     // If leaving polygon mode, clear draft
     if (get().canvasMode === "polygon") {
-      set({ canvasMode: mode, polygonDraftPoints: [], polygonDraftStepId: null });
+      set({ canvasMode: mode, buildView: bv, polygonDraftPoints: [], polygonDraftStepId: null });
     } else {
-      set({ canvasMode: mode });
+      set({ canvasMode: mode, buildView: bv });
     }
   },
 

--- a/src/store/build-slice.ts
+++ b/src/store/build-slice.ts
@@ -197,22 +197,15 @@ export interface BuildSlice {
   resetViewerState: () => void;
   requestFitToView: () => void;
 
-  // Build view (discriminated union — new primary state)
+  // Build view (discriminated union — primary mode state)
   buildView: BuildView;
   setBuildView: (view: BuildView) => void;
-
-  // Build mode (legacy — dual-written from buildView)
-  buildMode: BuildMode;
-  setBuildMode: (mode: BuildMode) => void;
   completeActiveStep: () => Promise<void>;
 
-  // Setup rail mode
+  // Legacy mode fields (internal — kept in sync by setBuildView, used by setCanvasMode validation)
+  buildMode: BuildMode;
   setupRailMode: SetupRailMode;
-  setSetupRailMode: (mode: SetupRailMode) => void;
-
-  // Nav mode
   navMode: NavMode;
-  setNavMode: (mode: NavMode) => void;
 
   // Sprue panel
   spruePanelOpen: boolean;
@@ -1183,36 +1176,31 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
   },
 
   setBuildView: (view) => {
-    const projectId = get().activeProjectId;
-    // Dual-write to legacy fields
+    const state = get();
+    const projectId = state.activeProjectId;
+    const prevView = state.buildView;
+    const wasSetup = prevView.kind === "setup-tracks" || prevView.kind === "setup-sprues";
     const isSetup = view.kind === "setup-tracks" || view.kind === "setup-sprues";
+    const isBuilding = !isSetup;
+
+    // Dual-write to legacy fields
     const legacyBuildMode: BuildMode = isSetup ? "setup" : "building";
     const legacyNavMode: NavMode = view.kind === "building-page" ? "page" : "track";
     const legacyCanvasMode: CanvasMode = ("canvasMode" in view ? view.canvasMode : "view") as CanvasMode;
     const legacyAnnotationMode: AnnotationTool = view.kind === "building-track" ? view.annotationMode : null;
     const legacySetupRailMode: SetupRailMode = view.kind === "setup-sprues" ? "sprues" : "steps";
-    set({
+
+    const updates: Partial<BuildSlice> = {
       buildView: view,
       buildMode: legacyBuildMode,
       navMode: legacyNavMode,
       canvasMode: legacyCanvasMode,
       annotationMode: legacyAnnotationMode,
       setupRailMode: legacySetupRailMode,
-    });
-    if (projectId) {
-      api.saveBuildView(projectId, view).catch((e) => toast.error(`Failed to save view state: ${e}`));
-    }
-  },
+    };
 
-  setBuildMode: async (mode) => {
-    const state = get();
-    const projectId = state.activeProjectId;
-    if (!projectId) return;
-
-    const updates: Partial<BuildSlice> = { buildMode: mode };
-
-    // Force canvas back to view mode and reset viewer when entering building
-    if (mode === "building") {
+    // Side effects when transitioning from setup → building
+    if (wasSetup && isBuilding) {
       updates.canvasMode = "view" as CanvasMode;
       updates.polygonDraftPoints = [];
       updates.polygonDraftStepId = null;
@@ -1228,59 +1216,18 @@ export const createBuildSlice: StateCreator<AppStore, [], [], BuildSlice> = (
       }
     }
 
-    // Clear annotation toolbar when switching modes
-    if (mode === "setup") {
-      updates.annotationMode = null as AnnotationTool;
-    }
-
-    // Dual-write buildView
-    if (mode === "building") {
-      updates.buildView = state.navMode === "page"
-        ? { kind: "building-page" }
-        : { kind: "building-track", annotationMode: null };
-    } else {
-      updates.buildView = { kind: "setup-tracks", canvasMode: "view" };
-    }
-
     set(updates);
 
     // Load step context for active step when entering building mode
-    if (mode === "building") {
-      const activeId = (updates as Record<string, unknown>).activeStepId as string ?? state.activeStepId;
+    if (wasSetup && isBuilding) {
+      const activeId = updates.activeStepId ?? state.activeStepId;
       if (activeId && !state.stepContexts[activeId]) {
         get().loadStepContext(activeId);
       }
     }
-    try {
-      await api.saveBuildMode(projectId, mode);
-      if (updates.buildView) api.saveBuildView(projectId, updates.buildView).catch(() => {});
-    } catch (e) {
-      toast.error(`Failed to save build mode: ${e}`);
-    }
-  },
 
-  setSetupRailMode: (mode) => {
-    const bv: BuildView = mode === "sprues"
-      ? { kind: "setup-sprues", canvasMode: "view" }
-      : { kind: "setup-tracks", canvasMode: get().canvasMode === "polygon" || get().canvasMode === "crop" ? get().canvasMode : "view" };
-    set({ setupRailMode: mode, buildView: bv });
-    const projectId = get().activeProjectId;
-    if (projectId) api.saveBuildView(projectId, bv).catch(() => {});
-  },
-
-  setNavMode: async (mode) => {
-    const projectId = get().activeProjectId;
-    const bv: BuildView = mode === "page"
-      ? { kind: "building-page" }
-      : { kind: "building-track", annotationMode: get().annotationMode };
-    set({ navMode: mode, buildView: bv });
     if (projectId) {
-      try {
-        await api.saveNavMode(projectId, mode);
-        api.saveBuildView(projectId, bv).catch(() => {});
-      } catch (e) {
-        toast.error(`Failed to save nav mode: ${e}`);
-      }
+      api.saveBuildView(projectId, view).catch((e) => toast.error(`Failed to save view state: ${e}`));
     }
   },
 


### PR DESCRIPTION
## Summary
- Replaces `buildMode`, `setupRailMode`, `navMode`, `canvasMode`, `annotationMode` with a single `BuildView` discriminated union that eliminates dead state combinations
- Extracts 70-line monolithic keydown handler into 3 focused hooks (`useSetupKeyboard`, `useBuildingKeyboard`, `useSharedKeyboard`)
- Reduces `routes/build.tsx` from 368 → 167 lines
- Adds V18 migration + `save_build_view` Rust command for DB persistence
- Removes legacy `save_build_mode` / `save_nav_mode` commands

Closes #17

## Test plan
- [ ] Switch between all 4 view modes (setup-tracks, setup-sprues, building-track, building-page)
- [ ] Verify keyboard shortcuts work in each mode (C/P/V in setup, 1-7/Space/arrows in building)
- [ ] Verify mode persists across app restart
- [ ] Verify annotation mode preserved when navigating steps
- [ ] Verify polygon draft cleared on mode transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)